### PR TITLE
NumpySourceBlock

### DIFF
--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -241,8 +241,9 @@ class MultiTransformBlock(object):
             for ring_name in args:
                 try:
                     dtype = np.dtype(self.header[ring_name]['dtype']).type
-                except:
-                    dtype = np.dtype(self.header[ring_name]['dtype'].split()[1].split(".")[1].split("'")[0]).type
+                except TypeError:
+                    numpy_dtype_word = self.header[ring_name]['dtype'].split()[1]
+                    dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
                 dtypes[ring_name] = dtype
             for spans in self.izip(*[sequence.read(self.gulp_size[ring_name]) \
                     for ring_name, sequence in self.izip(args, sequences)]):
@@ -273,8 +274,9 @@ class MultiTransformBlock(object):
                         for ring_name in args:
                             try:
                                 dtype = np.dtype(self.header[ring_name]['dtype']).type
-                            except:
-                                dtype = np.dtype(self.header[ring_name]['dtype'].split()[1].split(".")[1].split("'")[0]).type
+                            except TypeError:
+                                numpy_dtype_word = self.header[ring_name]['dtype'].split()[1]
+                                dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
                             dtypes[ring_name] = dtype
                         yield tuple([out_span.data_view(dtypes[ring_name])[0] for out_span, ring_name in self.izip(out_spans, args)])
 class SplitterBlock(MultiTransformBlock):
@@ -435,9 +437,10 @@ class IFFTBlock(TransformBlock):
         header = json.loads(input_header.tostring())
         self.nbit = header['nbit']
         try:
-            self.dtype = np.dtype(header['dtype'].split()[1].split(".")[1].split("'")[0]).type
-        except:
             self.dtype = np.dtype(header['dtype']).type
+        except TypeError:
+            numpy_dtype_word = header['dtype'].split()[1]
+            self.dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
         header['nbit'] = 64
         header['dtype'] = str(np.complex64)
         self.output_header = json.dumps(header)
@@ -480,8 +483,9 @@ class WriteAsciiBlock(SinkBlock):
         self.nbit = header_dict['nbit']
         try:
             self.dtype = np.dtype(header_dict['dtype']).type
-        except:
-            self.dtype = np.dtype(header_dict['dtype'].split()[1].split(".")[1].split("'")[0]).type
+        except TypeError:
+            numpy_dtype_word = header_dict['dtype'].split()[1]
+            self.dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
     def main(self, input_ring):
         """Initiate the writing to filename
         @param[in] input_rings First ring in this list will be used for
@@ -857,8 +861,9 @@ class NumpyBlock(MultiTransformBlock):
         for input_name in self.inputs:
             try:
                 dtype = np.dtype(self.header[input_name]['dtype']).type
-            except:
-                dtype = np.dtype(self.header[input_name]['dtype'].split()[1].split(".")[1].split("'")[0]).type
+            except TypeError:
+                numpy_dtype_word = self.header[input_name]['dtype'].split()[1]
+                dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
             array = np.zeros(shape=self.header[input_name]['shape'], dtype=dtype)
             self.gulp_size[input_name] = array.nbytes
             test_input_arrays.append(array)
@@ -885,8 +890,9 @@ class NumpyBlock(MultiTransformBlock):
             for i, input_name in enumerate(self.inputs):
                 try:
                     dtype = np.dtype(self.header[input_name]['dtype']).type
-                except:
-                    dtype = np.dtype(self.header[input_name]['dtype'].split()[1].split(".")[1].split("'")[0]).type
+                except TypeError:
+                    numpy_dtype_word = self.header[input_name]['dtype'].split()[1]
+                    dtype = np.dtype(numpy_dtype_word.split(".")[1].split("'")[0]).type
                 inspans[i] = inspans[i].view(dtype).reshape(self.header[input_name]['shape'])
             output_data = self.function(*inspans)
             if len(self.outputs) == 1:

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -666,5 +666,6 @@ class TestNumpySourceBlock(unittest.TestCase):
         blocks.append((NumpyBlock(assert_expectation, inputs=2, outputs=0), {'in_1': 0, 'in_2': 1}))
         Pipeline(blocks).main()
         self.assertEqual(self.occurences, 1)
+        #TODO: Add tests for defined 'rate' of numpy source block?
         #TODO: Add tests for changing output of generator
         #TODO: Add test for Pipeline calling _main, which sets core.


### PR DESCRIPTION
This block is similar to the NumpyBlock, except it takes a generator as an argument, and uses that generator to act as a SourceBlock.

It uses this to put data in a ring, automatically building the header based on the passed arrays. It also has an explicit mode, where the generator function can yield headers - these can contain extra information on the data, and will get appended to the ring sequence headers. 

**There is no current support for multiple sequences, but this could be added by having the NumpySourceBlock check the outputted header and/or data array with each iteration, and triggering a new sequence whenever this header changes.**

Examples (based on unit tests):

Generate 100 arrays of 4 elements each, and put them through 10 rings in parallel:

``` python

def generate_many_arrays():
    """Put out 10 4-element numpy arrays, 10 times"""
    for _ in range(10):
        yield (np.array([1, 2, 3, 4]).astype(np.float32),)*10

def assert_expectation(*args):
    """Assert the arrays are as expected"""
    assert len(args) == 10
    for array in args:
        np.testing.assert_almost_equal(array, [1, 2, 3, 4])

blocks = []
blocks.append((
    NumpySourceBlock(generate_many_arrays, outputs=10),
    {'out_%d'%(i+1):i for i in range(10)}))
blocks.append((
    NumpyBlock(assert_expectation, inputs=10, outputs=0),
    {'in_%d'%(i+1):i for i in range(10)}))
Pipeline(blocks).main()

```

Generate 2 different arrays, and define their data types explicitly through passed headers:

``` python
def generate_array_and_header():
    """Output the desired header of an array"""
    header_1 = {'dtype': 'complex128', 'nbit': 128}
    header_2 = {'dtype': 'complex64', 'nbit': 64}
    yield (
        np.array([1, 2, 3, 4]), header_1,
        np.array([1, 2]), header_2)

def assert_expectation(array1, array2):
    "Assert that the arrays have different complex datatypes"
    np.testing.assert_almost_equal(array1, [1, 2, 3, 4])
    np.testing.assert_almost_equal(array2, [1, 2])
    self.assertEqual(array1.dtype, np.dtype('complex128'))
    self.assertEqual(array2.dtype, np.dtype('complex64'))

blocks = []
blocks.append((
    NumpySourceBlock(generate_array_and_header, outputs=2, grab_headers=True),
    {'out_1': 0, 'out_2': 1}))
blocks.append((
    NumpyBlock(assert_expectation, inputs=2, outputs=0),
    {'in_1': 0, 'in_2': 1}))
Pipeline(blocks).main()
```
