### PR TITLE
GPU Unpack, take four

### DIFF
--- a/python/bifrost/DataType.py
+++ b/python/bifrost/DataType.py
@@ -132,9 +132,10 @@ class DataType(object):
             self._kind, self._nbit, self._veclen = t
         else:
             t = np.dtype(t) # Raises TypeError if t is invalid
-            if t.ndim == 0:
+            ndim = getattr(t, 'ndim', len(t.shape))
+            if ndim == 0:
                 self._veclen = 1
-            elif t.ndim == 1:
+            elif ndim == 1:
                 self._veclen = t.shape[0]
                 t = t.base
             else:

--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -571,6 +571,7 @@ class WriteAsciiBlock(SinkBlock):
                 data_accumulate = unpacked_data[0]
         text_file = open(self.filename, 'a')
         np.savetxt(text_file, data_accumulate.reshape((1, -1)))
+        text_file.close()
 class CopyBlock(TransformBlock):
     """Copies input ring's data to the output ring"""
     def __init__(self, gulp_size=1048576):

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,9 @@ ifndef NOCUDA
   trace.o \
   linalg.o \
   linalg_kernels.o \
-  reduce.o
+  reduce.o \
+  guantize.o \
+  gunpack.o
 endif
 
 JIT_SOURCES ?= \

--- a/src/guantize.cu
+++ b/src/guantize.cu
@@ -368,30 +368,102 @@ template class GuantizeFunctor<float,float,int32_t>;
 template class GuantizeFunctor<float,double,int32_t>;
 
 // Instantiation - launch_foreach_simple_gpu_1bit calls used in quantize.cpp
-template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in,
+                                                                                                int8_t*      out,
+                                                                                                size_t       nelement,
+                                                                                                GuantizeFunctor<float,float,uint8_t> func,
+                                                                                                cudaStream_t stream);
+template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in,
+                                                                                                 int8_t*      out,
+                                                                                                 size_t       nelement,
+                                                                                                 GuantizeFunctor<float,double,uint8_t> func,
+                                                                                                 cudaStream_t stream);
 
 // Instantiation - launch_foreach_simple_gpu_2bit calls used in quantize.cpp
-template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in,
+                                                                                                int8_t*      out,
+                                                                                                size_t       nelement,
+                                                                                                GuantizeFunctor<float,float,uint8_t> func,
+                                                                                                cudaStream_t stream);
+template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in,
+                                                                                                 int8_t*      out,
+                                                                                                 size_t       nelement,
+                                                                                                 GuantizeFunctor<float,double,uint8_t> func,
+                                                                                                 cudaStream_t stream);
 
 // Instantiation - launch_foreach_simple_gpu_4bit calls used in quantize.cpp
-template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in,
+                                                                                                int8_t*      out,
+                                                                                                size_t       nelement,
+                                                                                                GuantizeFunctor<float,float,uint8_t> func,
+                                                                                                cudaStream_t stream);
+template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in,
+                                                                                                 int8_t*      out,
+                                                                                                 size_t       nelement,
+                                                                                                 GuantizeFunctor<float,double,uint8_t> func,
+                                                                                                 cudaStream_t stream);
 
 // Instantiation - launch_foreach_simple_gpu calls used in quantize.cpp
 //// unsigned
-template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, uint8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, uint8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,float,uint16_t>,size_t>(float const* in, uint16_t* out, size_t nelement, GuantizeFunctor<float,float,uint16_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,double,uint16_t>,size_t>(float const* in, uint16_t* out, size_t nelement, GuantizeFunctor<float,double,uint16_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,float,uint32_t>,size_t>(float const* in, uint32_t* out, size_t nelement, GuantizeFunctor<float,float,uint32_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,double,uint32_t>,size_t>(float const* in, uint32_t* out, size_t nelement, GuantizeFunctor<float,double,uint32_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in,
+                                                                                                   uint8_t*     out,
+                                                                                                   size_t       nelement,
+                                                                                                   GuantizeFunctor<float,float,uint8_t> func,
+                                                                                                   cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in,
+                                                                                                    uint8_t*     out,
+                                                                                                    size_t       nelement,
+                                                                                                    GuantizeFunctor<float,double,uint8_t> func,
+                                                                                                    cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,float,uint16_t>,size_t>(float const* in,
+                                                                                                     uint16_t*    out,
+                                                                                                     size_t       nelement,
+                                                                                                     GuantizeFunctor<float,float,uint16_t> func,
+                                                                                                     cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,double,uint16_t>,size_t>(float const* in,
+                                                                                                      uint16_t*    out,
+                                                                                                      size_t       nelement,
+                                                                                                      GuantizeFunctor<float,double,uint16_t> func,
+                                                                                                      cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,float,uint32_t>,size_t>(float const* in,
+                                                                                                     uint32_t*    out,
+                                                                                                     size_t       nelement,
+                                                                                                     GuantizeFunctor<float,float,uint32_t> func,
+                                                                                                     cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,double,uint32_t>,size_t>(float const* in,
+                                                                                                      uint32_t*    out,
+                                                                                                      size_t       nelement,
+                                                                                                      GuantizeFunctor<float,double,uint32_t> func,
+                                                                                                      cudaStream_t stream);
 //// signed
-template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,float,int8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,int8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,double,int8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,int8_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,float,int16_t>,size_t>(float const* in, int16_t* out, size_t nelement, GuantizeFunctor<float,float,int16_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,double,int16_t>,size_t>(float const* in, int16_t* out, size_t nelement, GuantizeFunctor<float,double,int16_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,float,int32_t>,size_t>(float const* in, int32_t* out, size_t nelement, GuantizeFunctor<float,float,int32_t> func, cudaStream_t stream);
-template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,double,int32_t>,size_t>(float const* in, int32_t* out, size_t nelement, GuantizeFunctor<float,double,int32_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,float,int8_t>,size_t>(float const* in,
+                                                                                                 int8_t*      out,
+                                                                                                 size_t       nelement,
+                                                                                                 GuantizeFunctor<float,float,int8_t> func,
+                                                                                                 cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,double,int8_t>,size_t>(float const* in,
+                                                                                                  int8_t*      out,
+                                                                                                  size_t       nelement,
+                                                                                                  GuantizeFunctor<float,double,int8_t> func,
+                                                                                                  cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,float,int16_t>,size_t>(float const* in,
+                                                                                                   int16_t*     out,
+                                                                                                   size_t       nelement,
+                                                                                                   GuantizeFunctor<float,float,int16_t> func,
+                                                                                                   cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,double,int16_t>,size_t>(float const* in,
+                                                                                                    int16_t*     out,
+                                                                                                    size_t       nelement,
+                                                                                                    GuantizeFunctor<float,double,int16_t> func,
+                                                                                                    cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,float,int32_t>,size_t>(float const* in,
+                                                                                                   int32_t*     out,
+                                                                                                   size_t       nelement,
+                                                                                                   GuantizeFunctor<float,float,int32_t> func,
+                                                                                                   cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,double,int32_t>,size_t>(float const* in,
+                                                                                                    int32_t*     out,
+                                                                                                    size_t       nelement,
+                                                                                                    GuantizeFunctor<float,double,int32_t> func,
+                                                                                                    cudaStream_t stream);
 

--- a/src/guantize.cu
+++ b/src/guantize.cu
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2017, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017, The University of New Mexico. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "assert.hpp"
+#include "cuda.hpp"
+#include "utils.hu"
+
+#include <limits>
+#include <cmath>
+
+#include <iostream>
+
+using std::max;
+using std::min;
+
+template<typename I, typename F>
+inline __device__ F clip(F x) {
+	return min_gpu(max_gpu(x,F(minval_gpu<I>())),F(maxval_gpu<I>()));
+}
+
+template<typename F>
+inline __device__ F clip_4bit(F x) {
+	return min_gpu(max_gpu(x,F(-7)),F(7));
+}
+
+template<typename F>
+inline __device__ F clip_2bit(F x) {
+	return min_gpu(max_gpu(x,F(-1)),F(1));
+}
+
+template<typename F>
+inline __device__ F clip_1bit(F x) {
+	return x >= F(0) ? F(1) : F(0);
+}
+
+template<typename IType, typename SType, typename OType>
+__device__
+void guantize(IType ival, SType scale, OType& oval) {
+	//std::cout << (int)minval<OType>() << ", " << (int)maxval<OType>() << std::endl;
+	//std::cout << scale << std::endl;
+	//std::cout << ival
+	//          << " --> " << ival*scale
+	//          << " --> " << clip<OType>(ival*scale)
+	//          << " --> " << rint(clip<OType>(ival*scale))
+	//          << " --> " << (int)OType(rint(clip<OType>(ival*scale)))
+	//          << std::endl;
+	oval = OType(rint(clip<OType>(ival*scale)));
+}
+
+template<typename IType, typename SType, typename OType>
+struct GuantizeFunctor {
+	SType scale;
+	bool  byteswap_in;
+	bool  byteswap_out;
+	GuantizeFunctor(SType scale_, bool byteswap_in_, bool byteswap_out_)
+		: scale(scale_),
+		  byteswap_in(byteswap_in_),
+		  byteswap_out(byteswap_out_) {}
+	__device__ void operator()(IType ival, OType& oval) const {
+		if( byteswap_in ) {
+			byteswap_gpu(ival, &ival);
+		}
+		guantize(ival, scale, oval);
+		if( byteswap_out ) {
+			byteswap_gpu(oval, &oval);
+		}
+	}
+};
+
+template<typename T, typename U, typename Func, typename Size>
+__global__
+void foreach_simple_gpu(T const* in,
+                        U*       out,
+                        Size     nelement,
+                        Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	if( v0 < nelement ) {
+		func(in[v0], out[v0]);
+		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
+	}
+}
+
+template<typename T, typename U, typename Func, typename Size>
+inline void launch_foreach_simple_gpu(T const*     in,
+                                      U*           out,
+                                      Size         nelement,
+                                      Func         func,
+                                      cudaStream_t stream=0) {
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_simple_gpu<T,U,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream), 
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template<typename T, typename Func, typename Size>
+__global__
+void foreach_simple_gpu_4bit(T const* in,
+                             int8_t*  out,
+                             Size     nelement,
+                             Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	T tempR;
+	T tempI;
+	int8_t tempO;
+	if( v0 < nelement ) {
+		tempR = in[2*v0+0];
+		tempI = in[2*v0+1];
+		if(func.byteswap_in) {
+			byteswap_gpu(tempR, &tempR);
+			byteswap_gpu(tempI, &tempI);
+		}
+		//std::cout << tempR << ", " << tempI << " --> " << rint(clip_4bit(tempR)) << ", " << rint(clip_4bit(tempI)) << '\n';
+		tempO = (((int8_t(rint(clip_4bit(tempR*func.scale)))*16)     ) & 0xF0) | \
+			   (((int8_t(rint(clip_4bit(tempI*func.scale)))*16) >> 4) & 0x0F);
+		if(func.byteswap_out) {
+			byteswap_gpu(tempO, &tempO);
+		}
+		out[v0] = tempO;
+	}
+}
+
+template<typename T, typename Func, typename Size>
+inline void launch_foreach_simple_gpu_4bit(T const*     in,
+                                           int8_t*      out,
+                                           Size         nelement,
+                                           Func         func,
+                                           cudaStream_t stream=0) {
+	nelement /= 2;
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_simple_gpu_4bit<T,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream),
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template<typename T, typename Func, typename Size>
+__global__
+void foreach_simple_gpu_2bit(T const* in,
+                             int8_t*  out,
+                             Size     nelement,
+                             Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	T tempA;
+	T tempB;
+	T tempC;
+	T tempD;
+	int8_t tempO;
+	if( v0 < nelement ) {
+		tempA = in[4*v0+0];
+		tempB = in[4*v0+1];
+		tempC = in[4*v0+2];
+		tempD = in[4*v0+3];
+		if(func.byteswap_in) {
+			byteswap_gpu(tempA, &tempA);
+			byteswap_gpu(tempB, &tempB);
+			byteswap_gpu(tempC, &tempC);
+			byteswap_gpu(tempD, &tempD);
+		}
+		//std::cout << tempR << ", " << tempI << " --> " << rint(clip_4bit(tempR)) << ", " << rint(clip_4bit(tempI)) << '\n';
+		tempO = (((int8_t(rint(clip_2bit(tempA*func.scale)))*64)     ) & 0xC0) | \
+			   (((int8_t(rint(clip_2bit(tempB*func.scale)))*64) >> 2) & 0x30) | \
+			   (((int8_t(rint(clip_2bit(tempC*func.scale)))*64) >> 4) & 0x0C) | \
+			   (((int8_t(rint(clip_2bit(tempD*func.scale)))*64) >> 6) & 0x03);
+		if(func.byteswap_out) {
+			byteswap_gpu(tempO, &tempO);
+		}
+		out[v0] = tempO;
+	}
+}
+
+template<typename T, typename Func, typename Size>
+inline void launch_foreach_simple_gpu_2bit(T const*     in,
+                                           int8_t*      out,
+                                           Size         nelement,
+                                           Func         func,
+                                           cudaStream_t stream=0) {
+	nelement /= 4;
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_simple_gpu_2bit<T,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream),
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template<typename T, typename Func, typename Size>
+__global__
+void foreach_simple_gpu_1bit(T const* in,
+                             int8_t*  out,
+                             Size     nelement,
+                             Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	T tempA;
+	T tempB;
+	T tempC;
+	T tempD;
+	T tempE;
+	T tempF;
+	T tempG;
+	T tempH;
+	int8_t tempO;
+	if( v0 < nelement ) {
+		tempA = in[8*v0+0];
+		tempB = in[8*v0+1];
+		tempC = in[8*v0+2];
+		tempD = in[8*v0+3];
+		tempE = in[8*v0+4];
+		tempF = in[8*v0+5];
+		tempG = in[8*v0+6];
+		tempH = in[8*v0+7];
+		if(func.byteswap_in) {
+			byteswap_gpu(tempA, &tempA);
+			byteswap_gpu(tempB, &tempB);
+			byteswap_gpu(tempC, &tempC);
+			byteswap_gpu(tempD, &tempD);
+			byteswap_gpu(tempE, &tempE);
+			byteswap_gpu(tempF, &tempF);
+			byteswap_gpu(tempG, &tempG);
+			byteswap_gpu(tempH, &tempH);
+		}
+		//std::cout << tempR << ", " << tempI << " --> " << rint(clip_4bit(tempR)) << ", " << rint(clip_4bit(tempI)) << '\n';
+		tempO = (((int8_t(rint(clip_1bit(tempA*func.scale)))*128)     ) & 0x08) | \
+			   (((int8_t(rint(clip_1bit(tempB*func.scale)))*128) >> 1) & 0x04) | \
+			   (((int8_t(rint(clip_1bit(tempC*func.scale)))*128) >> 2) & 0x02) | \
+			   (((int8_t(rint(clip_1bit(tempD*func.scale)))*128) >> 3) & 0x10) | \
+			   (((int8_t(rint(clip_1bit(tempE*func.scale)))*128) >> 4) & 0x08) | \
+			   (((int8_t(rint(clip_1bit(tempF*func.scale)))*128) >> 5) & 0x04) | \
+			   (((int8_t(rint(clip_1bit(tempG*func.scale)))*128) >> 6) & 0x02) | \
+			   (((int8_t(rint(clip_1bit(tempH*func.scale)))*128) >> 7) & 0x01);
+		if(func.byteswap_out) {
+			byteswap_gpu(tempO, &tempO);
+		}
+		out[v0] = tempO;
+	}
+}
+
+template<typename T, typename Func, typename Size>
+inline void launch_foreach_simple_gpu_1bit(T const*     in,
+                                           int8_t*      out,
+                                           Size         nelement,
+                                           Func         func,
+                                           cudaStream_t stream=0) {
+	nelement /= 8;
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_simple_gpu_1bit<T,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream),
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template class GuantizeFunctor<float,float,uint8_t>;
+template class GuantizeFunctor<float,double,uint8_t>;
+template class GuantizeFunctor<float,float,uint16_t>;
+template class GuantizeFunctor<float,double,uint16_t>;
+template class GuantizeFunctor<float,float,uint32_t>;
+template class GuantizeFunctor<float,double,uint32_t>;
+template class GuantizeFunctor<float,float,int8_t>;
+template class GuantizeFunctor<float,double,int8_t>;
+template class GuantizeFunctor<float,float,int16_t>;
+template class GuantizeFunctor<float,double,int16_t>;
+template class GuantizeFunctor<float,float,int32_t>;
+template class GuantizeFunctor<float,double,int32_t>;
+
+template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_1bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_2bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu_4bit<float,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,float,uint8_t>,size_t>(float const* in, uint8_t* out, size_t nelement, GuantizeFunctor<float,float,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint8_t,GuantizeFunctor<float,double,uint8_t>,size_t>(float const* in, uint8_t* out, size_t nelement, GuantizeFunctor<float,double,uint8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,float,uint16_t>,size_t>(float const* in, uint16_t* out, size_t nelement, GuantizeFunctor<float,float,uint16_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint16_t,GuantizeFunctor<float,double,uint16_t>,size_t>(float const* in, uint16_t* out, size_t nelement, GuantizeFunctor<float,double,uint16_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,float,uint32_t>,size_t>(float const* in, uint32_t* out, size_t nelement, GuantizeFunctor<float,float,uint32_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,uint32_t,GuantizeFunctor<float,double,uint32_t>,size_t>(float const* in, uint32_t* out, size_t nelement, GuantizeFunctor<float,double,uint32_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,float,int8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,float,int8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int8_t,GuantizeFunctor<float,double,int8_t>,size_t>(float const* in, int8_t* out, size_t nelement, GuantizeFunctor<float,double,int8_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,float,int16_t>,size_t>(float const* in, int16_t* out, size_t nelement, GuantizeFunctor<float,float,int16_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int16_t,GuantizeFunctor<float,double,int16_t>,size_t>(float const* in, int16_t* out, size_t nelement, GuantizeFunctor<float,double,int16_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,float,int32_t>,size_t>(float const* in, int32_t* out, size_t nelement, GuantizeFunctor<float,float,int32_t> func, cudaStream_t stream);
+template void launch_foreach_simple_gpu<float,int32_t,GuantizeFunctor<float,double,int32_t>,size_t>(float const* in, int32_t* out, size_t nelement, GuantizeFunctor<float,double,int32_t> func, cudaStream_t stream);

--- a/src/guantize.hu
+++ b/src/guantize.hu
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017, The University of New Mexico. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+#ifndef BF_GUANTIZE_HU_INCLUDE_GUARD_
+#define BF_GUANTIZE_HU_INCLUDE_GUARD_
+
+template<typename IType, typename SType, typename OType>
+struct GuantizeFunctor {
+	SType scale;
+	bool  byteswap_in;
+	bool  byteswap_out;
+	GuantizeFunctor(SType scale_, bool byteswap_in_, bool byteswap_out_);
+	__device__ void operator()(IType ival, OType& oval);
+};
+
+template<typename T, typename U, typename Func, typename Size>
+void launch_foreach_simple_gpu(T const*     in,
+                               U*           out,
+                               Size         nelement,
+                               Func         func,
+                               cudaStream_t stream=0);
+
+template<typename T, typename Func, typename Size>
+void launch_foreach_simple_gpu_4bit(T const*     in,
+                                    int8_t*      out,
+                                    Size         nelement,
+                                    Func         func,
+                                    cudaStream_t stream=0);
+
+template<typename T, typename Func, typename Size>
+void launch_foreach_simple_gpu_2bit(T const*     in,
+                                    int8_t*      out,
+                                    Size         nelement,
+                                    Func         func,
+                                    cudaStream_t stream=0);
+
+template<typename T, typename Func, typename Size>
+void launch_foreach_simple_gpu_1bit(T const*     in,
+                                    int8_t*      out,
+                                    Size         nelement,
+                                    Func         func,
+                                    cudaStream_t stream=0);
+
+#endif // BF_GUANTIZE_HU_INCLUDE_GUARD_

--- a/src/guantize.hu
+++ b/src/guantize.hu
@@ -69,3 +69,4 @@ void launch_foreach_simple_gpu_1bit(T const*     in,
                                     cudaStream_t stream=0);
 
 #endif // BF_GUANTIZE_HU_INCLUDE_GUARD_
+

--- a/src/gunpack.cu
+++ b/src/gunpack.cu
@@ -31,7 +31,6 @@
 #include "assert.hpp"
 #include "cuda.hpp"
 #include "utils.hu"
-//#include "gunpack.hu"
 
 // HACK TESTING
 #include <iostream>
@@ -208,7 +207,6 @@ __global__ void foreach_simple_gpu(T const* in,
 	
 	if( v0 < nelement ) {
 		func(in[v0], out[v0]);
-		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
 	}
 }
 
@@ -218,7 +216,6 @@ inline void launch_foreach_simple_gpu(T const*     in,
                                       Size         nelement,
                                       Func         func,
                                       cudaStream_t stream) {
-	//cout << "LAUNCH for " << nelement << endl;
 	dim3 block(512, 1); // TODO: Tune this
 	Size first = std::min((nelement-1)/block.x+1, 65535ul);
 	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
@@ -259,7 +256,6 @@ __global__ void foreach_promote_gpu(T const* in,
 		for( Size j=0; j<sizeof(U)/sizeof(T); j++ ) {
 			out[v0*sizeof(U)/sizeof(T) + j] = int8_t((tmp2 >> j*8) & 0xFF);
 		}
-		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
 	}
 }
 
@@ -270,7 +266,6 @@ inline void launch_foreach_promote_gpu(T const*     in,
                                        Size         nelement,
                                        Func         func,
                                        cudaStream_t stream) {
-	//cout << "LAUNCH for " << nelement << endl;
 	dim3 block(512, 1); // TODO: Tune this
 	Size first = std::min((nelement-1)/block.x+1, 65535ul);
 	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
@@ -298,23 +293,33 @@ inline void launch_foreach_promote_gpu(T const*     in,
 	                        BF_STATUS_INTERNAL_ERROR);
 }
 
+// Instantiation - Gunpack functors used in unpack.cpp
+//// unsigned
 template class GunpackFunctor<uint8_t,uint16_t>;
 template class GunpackFunctor<uint8_t,uint32_t>;
 template class GunpackFunctor<uint8_t,uint64_t>;
+//// signed
 template class GunpackFunctor<uint8_t,int16_t>;
 template class GunpackFunctor<uint8_t,int32_t>;
 template class GunpackFunctor<uint8_t,int64_t>;
 
+// Instantiation - launch_foreach_simple_gpu calls used in unpack.cpp
+//// unsigned
 template void launch_foreach_simple_gpu<uint8_t,uint16_t,GunpackFunctor<uint8_t,uint16_t>,size_t>(uint8_t const *in, uint16_t* out,size_t nelement,GunpackFunctor<uint8_t,uint16_t> func,cudaStream_t stream);
 template void launch_foreach_simple_gpu<uint8_t,uint32_t,GunpackFunctor<uint8_t,uint32_t>,size_t>(uint8_t const *in, uint32_t* out,size_t nelement,GunpackFunctor<uint8_t,uint32_t> func,cudaStream_t stream);
 template void launch_foreach_simple_gpu<uint8_t,uint64_t,GunpackFunctor<uint8_t,uint64_t>,size_t>(uint8_t const *in, uint64_t* out,size_t nelement,GunpackFunctor<uint8_t,uint64_t> func,cudaStream_t stream);
+//// signed
 template void launch_foreach_simple_gpu<uint8_t,int16_t,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
 template void launch_foreach_simple_gpu<uint8_t,int32_t,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
 template void launch_foreach_simple_gpu<uint8_t,int64_t,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
 
-template void launch_foreach_promote_gpu<uint8_t,int64_t,float,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int32_t,float,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+// Instantiation - launch_foreach_promote_gpu calls used in unpack.cpp
+//// promote to float
 template void launch_foreach_promote_gpu<uint8_t,int16_t,float,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int64_t,double,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int32_t,double,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,float,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int64_t,float,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+//// promote to double
 template void launch_foreach_promote_gpu<uint8_t,int16_t,double,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,double,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int64_t,double,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+

--- a/src/gunpack.cu
+++ b/src/gunpack.cu
@@ -305,21 +305,75 @@ template class GunpackFunctor<uint8_t,int64_t>;
 
 // Instantiation - launch_foreach_simple_gpu calls used in unpack.cpp
 //// unsigned
-template void launch_foreach_simple_gpu<uint8_t,uint16_t,GunpackFunctor<uint8_t,uint16_t>,size_t>(uint8_t const *in, uint16_t* out,size_t nelement,GunpackFunctor<uint8_t,uint16_t> func,cudaStream_t stream);
-template void launch_foreach_simple_gpu<uint8_t,uint32_t,GunpackFunctor<uint8_t,uint32_t>,size_t>(uint8_t const *in, uint32_t* out,size_t nelement,GunpackFunctor<uint8_t,uint32_t> func,cudaStream_t stream);
-template void launch_foreach_simple_gpu<uint8_t,uint64_t,GunpackFunctor<uint8_t,uint64_t>,size_t>(uint8_t const *in, uint64_t* out,size_t nelement,GunpackFunctor<uint8_t,uint64_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,uint16_t,GunpackFunctor<uint8_t,uint16_t>,size_t>(uint8_t const* in,
+                                                                                                  uint16_t*      out,
+                                                                                                  size_t         nelement,
+                                                                                                  GunpackFunctor<uint8_t,uint16_t> func,
+                                                                                                  cudaStream_t   stream);
+template void launch_foreach_simple_gpu<uint8_t,uint32_t,GunpackFunctor<uint8_t,uint32_t>,size_t>(uint8_t const* in,
+                                                                                                  uint32_t*      out,
+                                                                                                  size_t         nelement,
+                                                                                                  GunpackFunctor<uint8_t,uint32_t> func,
+                                                                                                  cudaStream_t   stream);
+template void launch_foreach_simple_gpu<uint8_t,uint64_t,GunpackFunctor<uint8_t,uint64_t>,size_t>(uint8_t const* in,
+                                                                                                  uint64_t*      out,
+                                                                                                  size_t         nelement,
+                                                                                                  GunpackFunctor<uint8_t,uint64_t> func,
+                                                                                                  cudaStream_t   stream);
 //// signed
-template void launch_foreach_simple_gpu<uint8_t,int16_t,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
-template void launch_foreach_simple_gpu<uint8_t,int32_t,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
-template void launch_foreach_simple_gpu<uint8_t,int64_t,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,int16_t,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const* in,
+                                                                                                int16_t*       out,
+                                                                                                size_t         nelement,
+                                                                                                GunpackFunctor<uint8_t,int16_t> func,
+                                                                                                cudaStream_t   stream);
+template void launch_foreach_simple_gpu<uint8_t,int32_t,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const* in,
+                                                                                                int32_t*       out,
+                                                                                                size_t         nelement,
+                                                                                                GunpackFunctor<uint8_t,int32_t> func,
+                                                                                                cudaStream_t   stream);
+template void launch_foreach_simple_gpu<uint8_t,int64_t,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in,
+                                                                                                int64_t*       out,
+                                                                                                size_t         nelement,
+                                                                                                GunpackFunctor<uint8_t,int64_t> func,
+                                                                                                cudaStream_t   stream);
 
 // Instantiation - launch_foreach_promote_gpu calls used in unpack.cpp
 //// promote to float
-template void launch_foreach_promote_gpu<uint8_t,int16_t,float,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int32_t,float,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int64_t,float,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int16_t,float,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const* in,
+                                                                                                       int16_t*       tmp,
+                                                                                                       float*         out,
+                                                                                                       size_t         nelement,
+                                                                                                       GunpackFunctor<uint8_t,int16_t> func,
+                                                                                                       cudaStream_t   stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,float,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const* in,
+                                                                                                       int32_t*       tmp,
+                                                                                                       float*         out,
+                                                                                                       size_t         nelement,
+                                                                                                       GunpackFunctor<uint8_t,int32_t> func,
+                                                                                                       cudaStream_t   stream);
+template void launch_foreach_promote_gpu<uint8_t,int64_t,float,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const* in,
+                                                                                                       int64_t*       tmp,
+                                                                                                       float*         out,
+                                                                                                       size_t         nelement,
+                                                                                                       GunpackFunctor<uint8_t,int64_t> func,
+                                                                                                       cudaStream_t   stream);
 //// promote to double
-template void launch_foreach_promote_gpu<uint8_t,int16_t,double,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int32_t,double,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
-template void launch_foreach_promote_gpu<uint8_t,int64_t,double,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int16_t,double,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const* in,
+                                                                                                        int16_t*       tmp,
+                                                                                                        double*        out,
+                                                                                                        size_t         nelement,
+                                                                                                        GunpackFunctor<uint8_t,int16_t> func,
+                                                                                                        cudaStream_t   stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,double,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const* in,
+                                                                                                        int32_t*       tmp,
+                                                                                                        double*        out,
+                                                                                                        size_t         nelement,
+                                                                                                        GunpackFunctor<uint8_t,int32_t> func,
+                                                                                                        cudaStream_t   stream);
+template void launch_foreach_promote_gpu<uint8_t,int64_t,double,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const* in,
+                                                                                                        int64_t*       tmp,
+                                                                                                        double*        out,
+                                                                                                        size_t         nelement,
+                                                                                                        GunpackFunctor<uint8_t,int64_t> func,
+                                                                                                        cudaStream_t   stream);
 

--- a/src/gunpack.cu
+++ b/src/gunpack.cu
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2017, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017, The University of New Mexico. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "assert.hpp"
+#include "cuda.hpp"
+#include "utils.hu"
+//#include "gunpack.hu"
+
+// HACK TESTING
+#include <iostream>
+using std::cout;
+using std::endl;
+
+// 2x 4-bit --> 2x 8-bit (unsigned)
+inline __device__ void gunpack(uint8_t   ival,
+                               uint16_t& oval,
+                               bool      byte_reverse,
+                               bool      align_msb,
+                               bool      conjugate) {
+	// Note: Ignores conjugate
+	if( byte_reverse ) {
+		// ........ABCDEFGH
+		// EFGH....ABCD....
+		oval = ival;
+		oval = (oval | (oval << 12)) & 0xF0F0;
+	} else {
+		// ....ABCDEFGH....
+		// ABCD....EFGH....
+		oval = ival << 4;
+		oval = (oval | (oval <<  4)) & 0xF0F0;
+	}
+	if( !align_msb ) {
+		// >>>>ABCD>>>>EFGH
+		oval >>= 4;
+	}
+}
+
+// 4x 2-bit --> 4x 8-bit (unsigned)
+inline __device__ void gunpack(uint8_t   ival,
+                               uint32_t& oval,
+                               bool      byte_reverse,
+                               bool      align_msb,
+                               bool      conjugate) {
+	// Note: Ignores conjugate
+	// ..................ABCDEFGH......
+	// ......ABCD............EFGH......
+	// AB......CD......EF......GH......
+	oval = ival << 6;
+	oval = (oval | (oval << 12)) & 0x03C003C0;
+	oval = (oval | (oval <<  6)) & 0xC0C0C0C0;
+	if( byte_reverse) {
+		byteswap_gpu(oval, &oval);
+	}
+	if( !align_msb ) {
+		// >>>>>>AB>>>>>>CD>>>>>>EF>>>>>>GH
+		oval >>= 6;
+	}
+}
+
+// 8x 1-bit --> 8x 8-bit (unsigned)
+inline __device__ void gunpack(uint8_t   ival,
+                                        uint64_t& oval,
+                                        bool      byte_reverse,
+                                        bool      align_msb,
+                                        bool      conjugate) {
+	// Note: Ignores conjugate
+	// .................................................ABCDEFGH.......
+	// .....................ABCD............................EFGH.......
+	// .......AB..............CD..............EF..............GH.......
+	// A.......B.......C.......D.......E.......F.......G.......H.......
+	oval = ival << 7;
+	oval = (oval | (oval << 28)) & 0x0000078000000780;
+	oval = (oval | (oval << 14)) & 0x0180018001800180;
+	oval = (oval | (oval <<  7)) & 0x8080808080808080;
+	if( byte_reverse) {
+		byteswap_gpu(oval, &oval);
+	}
+	if( !align_msb ) {
+		// >>>>>>>A>>>>>>>B>>>>>>>C>>>>>>>D
+		oval >>= 7;
+	}
+}
+
+// 2x 4-bit --> 2x 8-bit (signed)
+inline __device__ void gunpack(uint8_t  ival,
+                               int16_t& oval,
+                               bool     byte_reverse,
+                               bool     align_msb,
+                               bool     conjugate) {
+	if( byte_reverse ) {
+		// ........ABCDEFGH
+		// EFGH....ABCD....
+		oval = ival;
+		oval = (oval | (oval << 12)) & 0xF0F0;
+	} else {
+		// ....ABCDEFGH....
+		// ABCD....EFGH....
+		oval = ival << 4;
+		oval = (oval | (oval <<  4)) & 0xF0F0;
+	}
+	if( !align_msb ) {
+		// >>>>ABCD>>>>EFGH
+		rshift_subwords_gpu<4,int8_t>(oval);
+	}
+	if( conjugate ) {
+		conjugate_subwords_gpu<int8_t>(oval);
+	}
+}
+// 4x 2-bit --> 4x 8-bit (signed)
+inline __device__ void gunpack(uint8_t  ival,
+                               int32_t& oval,
+                               bool     byte_reverse,
+                               bool     align_msb,
+                               bool     conjugate) {
+	// ..................ABCDEFGH......
+	// ......ABCD............EFGH......
+	// AB......CD......EF......GH......
+	oval = ival << 6;
+	oval = (oval | (oval << 12)) & 0x03C003C0;
+	oval = (oval | (oval <<  6)) & 0xC0C0C0C0;
+	if( byte_reverse) {
+		byteswap_gpu(oval, &oval);
+	}
+	if( !align_msb ) {
+		// >>>>>>AB>>>>>>CD>>>>>>EF>>>>>>GH
+		rshift_subwords_gpu<6,int8_t>(oval);
+	}
+	if( conjugate ) {
+		conjugate_subwords_gpu<int8_t>(oval);
+	}
+}
+// 8x 1-bit --> 8x 8-bit (signed)
+inline __device__ void gunpack(uint8_t  ival,
+                                        int64_t& oval,
+                                        bool     byte_reverse,
+                                        bool     align_msb,
+                                        bool     conjugate) {
+	// .................................................ABCDEFGH.......
+	// .....................ABCD............................EFGH.......
+	// .......AB..............CD..............EF..............GH.......
+	// A.......B.......C.......D.......E.......F.......G.......H.......
+	oval = (~ival) << 7;
+	oval = (oval | (oval << 28)) & 0x0000078000000780;
+	oval = (oval | (oval << 14)) & 0x0180018001800180;
+	oval = (oval | (oval <<  7)) & 0x8080808080808080;
+	oval |= 0x4040404040404040;
+	if( byte_reverse) {
+		byteswap_gpu(oval, &oval);
+	}
+	if( !align_msb ) {
+		// >>>>>>>A>>>>>>>B>>>>>>>C>>>>>>>D
+		rshift_subwords_gpu<6,int8_t>(oval);
+	}
+	if( conjugate ) {
+		conjugate_subwords_gpu<int8_t>(oval);
+	}
+}
+
+template<typename IType, typename OType>
+struct GunpackFunctor {
+	bool byte_reverse;
+	bool align_msb;
+	bool conjugate;
+	GunpackFunctor(bool byte_reverse_,
+	              bool align_msb_,
+	              bool conjugate_)
+		: byte_reverse(byte_reverse_),
+		  align_msb(align_msb_),
+		  conjugate(conjugate_) {}
+	__device__ void operator()(IType ival, OType& oval) const {
+		gunpack(ival, oval, byte_reverse, align_msb, conjugate);
+	}
+};
+
+template<typename T, typename U, typename Func, typename Size>
+__global__ void foreach_simple_gpu(T const* in,
+                                   U*       out,
+                                   Size     nelement,
+                                   Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	if( v0 < nelement ) {
+		func(in[v0], out[v0]);
+		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
+	}
+}
+
+template<typename T, typename U, typename Func, typename Size>
+inline void launch_foreach_simple_gpu(T const*     in,
+                                      U*           out,
+                                      Size         nelement,
+                                      Func         func,
+                                      cudaStream_t stream) {
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_simple_gpu<T,U,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream),
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template<typename T, typename U, typename V, typename Func, typename Size>
+__global__ void foreach_promote_gpu(T const* in,
+                                    V*       out,
+                                    Size     nelement,
+                                    Func     func) {
+	Size v0 = threadIdx.x + (blockIdx.x + blockIdx.y*gridDim.x)*blockDim.x;
+	
+	if( v0 < nelement ) {
+		U tmp2 = 0;
+		func(in[v0], tmp2);
+		for( Size j=0; j<sizeof(U)/sizeof(T); j++ ) {
+			out[v0*sizeof(U)/sizeof(T) + j] = int8_t((tmp2 >> j*8) & 0xFF);
+		}
+		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
+	}
+}
+
+template<typename T, typename U, typename V, typename Func, typename Size>
+inline void launch_foreach_promote_gpu(T const*     in,
+                                       U*           tmp,
+                                       V*           out,
+                                       Size         nelement,
+                                       Func         func,
+                                       cudaStream_t stream) {
+	//cout << "LAUNCH for " << nelement << endl;
+	dim3 block(512, 1); // TODO: Tune this
+	Size first = std::min((nelement-1)/block.x+1, 65535ul);
+	Size secnd = std::min((nelement - first*block.x) / first + 1, 65535ul);
+	if( block.x*first > nelement ) {
+		secnd = 1;
+	}
+	
+	dim3 grid(first, secnd);
+	/*
+	cout << "  Block size is " << block.x << " by " << block.y << endl;
+	cout << "  Grid  size is " << grid.x << " by " << grid.y << endl;
+	cout << "  Maximum size is " << block.x*grid.x*grid.y << endl;
+	if( block.x*grid.x*grid.y >= nelement ) {
+		cout << "  -> Valid" << endl;
+	}
+	*/
+	
+	void* args[] = {&in,
+	                &out, 
+	                &nelement, 
+	                &func};
+	BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)foreach_promote_gpu<T,U,V,Func,Size>,
+	                                         grid, block,
+	                                         &args[0], 0, stream),
+	                        BF_STATUS_INTERNAL_ERROR);
+}
+
+template class GunpackFunctor<uint8_t,uint16_t>;
+template class GunpackFunctor<uint8_t,uint32_t>;
+template class GunpackFunctor<uint8_t,uint64_t>;
+template class GunpackFunctor<uint8_t,int16_t>;
+template class GunpackFunctor<uint8_t,int32_t>;
+template class GunpackFunctor<uint8_t,int64_t>;
+
+template void launch_foreach_simple_gpu<uint8_t,uint16_t,GunpackFunctor<uint8_t,uint16_t>,size_t>(uint8_t const *in, uint16_t* out,size_t nelement,GunpackFunctor<uint8_t,uint16_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,uint32_t,GunpackFunctor<uint8_t,uint32_t>,size_t>(uint8_t const *in, uint32_t* out,size_t nelement,GunpackFunctor<uint8_t,uint32_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,uint64_t,GunpackFunctor<uint8_t,uint64_t>,size_t>(uint8_t const *in, uint64_t* out,size_t nelement,GunpackFunctor<uint8_t,uint64_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,int16_t,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,int32_t,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_simple_gpu<uint8_t,int64_t,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+
+template void launch_foreach_promote_gpu<uint8_t,int64_t,float,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,float,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int16_t,float,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, float* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int64_t,double,GunpackFunctor<uint8_t,int64_t>,size_t>(uint8_t const *in, int64_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int64_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int32_t,double,GunpackFunctor<uint8_t,int32_t>,size_t>(uint8_t const *in, int32_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int32_t> func,cudaStream_t stream);
+template void launch_foreach_promote_gpu<uint8_t,int16_t,double,GunpackFunctor<uint8_t,int16_t>,size_t>(uint8_t const *in, int16_t* tmp, double* out,size_t nelement,GunpackFunctor<uint8_t,int16_t> func,cudaStream_t stream);

--- a/src/gunpack.hu
+++ b/src/gunpack.hu
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017, The University of New Mexico. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+#ifndef BF_GUNPACK_HU_INCLUDE_GUARD_
+#define BF_GUNPACK_HU_INCLUDE_GUARD_
+
+template<typename IType, typename OType>
+struct GunpackFunctor {
+	bool byte_reverse;
+	bool align_msb;
+	bool conjugate;
+	GunpackFunctor(bool byte_reverse_, bool align_msb_, bool conjugate_);
+	__device__ void operator()(IType ival, OType& oval);
+};
+
+template<typename T, typename U, typename Func, typename Size>
+void launch_foreach_simple_gpu(T const*     in,
+                               U*           out,
+                               Size         nelement,
+                               Func         func,
+                               cudaStream_t stream=0);
+
+template<typename T, typename U, typename V, typename Func, typename Size>
+void launch_foreach_promote_gpu(T const*     in,
+                                U*           tmp,
+                                V*           out,
+                                Size         nelement,
+                                Func         func,
+                                cudaStream_t stream=0);
+
+#endif // BF_GUNPACK_HU_INCLUDE_GUARD_

--- a/src/gunpack.hu
+++ b/src/gunpack.hu
@@ -56,3 +56,4 @@ void launch_foreach_promote_gpu(T const*     in,
                                 cudaStream_t stream=0);
 
 #endif // BF_GUNPACK_HU_INCLUDE_GUARD_
+

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -29,6 +29,10 @@
 #include <bifrost/unpack.h>
 #include "utils.hpp"
 
+#ifdef BF_CUDA_ENABLED
+#include <gunpack.hu>
+#endif
+
 // sign_extend == true  => output has same value as input  (slower)
 // sign_extend == false => output is scaled by 2**(8-nbit) (faster)
 
@@ -217,6 +221,22 @@ void foreach_simple_cpu(T const* in,
 	}
 }
 
+template<typename T, typename U, typename V, typename Func, typename Size>
+void foreach_promote_cpu(T const* in,
+					U*       tmp,
+					V*       out,
+					Size     nelement,
+					Func     func) {
+	U tmp2 = 0;
+	for( Size i=0; i<nelement; ++i ) {
+		func(in[i], tmp2);
+		for( Size j=0; j<sizeof(U)/sizeof(T); j++ ) {
+			out[i*sizeof(U)/sizeof(T) + j] = int8_t((tmp2 >> j*8) & 0xFF);
+		}
+		//std::cout << std::hex << (int)in[i] << " --> " << (int)out[i] << std::endl;
+	}
+}
+
 BFstatus bfUnpack(BFarray const* in,
                   BFarray const* out,
                   BFbool         align_msb) {
@@ -242,15 +262,29 @@ BFstatus bfUnpack(BFarray const* in,
 	BF_ASSERT(is_contiguous(in),  BF_STATUS_UNSUPPORTED_STRIDE);
 	BF_ASSERT(is_contiguous(out), BF_STATUS_UNSUPPORTED_STRIDE);
 	
-	// TODO: Support CUDA space
+#ifdef BF_CUDA_ENABLED
+	BF_ASSERT(space_accessible_from(in->space, BF_SPACE_SYSTEM) || (space_accessible_from(in->space, BF_SPACE_CUDA) && space_accessible_from(out->space, BF_SPACE_CUDA)),
+	          BF_STATUS_UNSUPPORTED_SPACE);
+	BF_ASSERT(space_accessible_from(out->space, BF_SPACE_SYSTEM) || (space_accessible_from(in->space, BF_SPACE_CUDA) && space_accessible_from(out->space, BF_SPACE_CUDA)),
+	          BF_STATUS_UNSUPPORTED_SPACE);
+#else
 	BF_ASSERT(space_accessible_from(in->space, BF_SPACE_SYSTEM),
 	          BF_STATUS_UNSUPPORTED_SPACE);
 	BF_ASSERT(space_accessible_from(out->space, BF_SPACE_SYSTEM),
 	          BF_STATUS_UNSUPPORTED_SPACE);
+#endif
 	
 	size_t nelement = num_contiguous_elements(in);
 	bool byteswap    = ( in->big_endian != is_big_endian());
 	bool conjugate   = (in->conjugated != out->conjugated);
+	
+#ifdef BF_CUDA_ENABLED
+	if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+		BF_ASSERT(nelement<=(size_t)512*65535*65535, BF_STATUS_UNSUPPORTED_SHAPE);
+	}
+#endif
+	
+	float not_really_used = 0;
 	
 #define CALL_FOREACH_SIMPLE_CPU_UNPACK(itype,otype) \
 	foreach_simple_cpu((itype*)in->data, \
@@ -259,29 +293,84 @@ BFstatus bfUnpack(BFarray const* in,
 	                   UnpackFunctor<itype,otype>(byteswap, \
 	                                              align_msb, \
 	                                              conjugate))
+	                                              
+#define CALL_FOREACH_PROMOTE_CPU_UNPACK(itype,ttype,otype) \
+	foreach_promote_cpu((itype*)in->data, \
+	                    (ttype*)&not_really_used, \
+	                    (otype*)out->data, \
+	                    nelement, \
+	                    UnpackFunctor<itype,ttype>(byteswap, \
+	                                               align_msb, \
+	                                               conjugate))
+	                                              
+#ifdef BF_CUDA_ENABLED
+#define CALL_FOREACH_SIMPLE_GPU_UNPACK(itype,otype) \
+	launch_foreach_simple_gpu((itype*)in->data, \
+	                          (otype*)out->data, \
+	                          nelement, \
+	                          GunpackFunctor<itype,otype>(byteswap, \
+	                                                      align_msb, \
+	                                                      conjugate), \
+	                          (cudaStream_t)0)
+	                          
+#define CALL_FOREACH_PROMOTE_GPU_UNPACK(itype,ttype,otype) \
+	launch_foreach_promote_gpu((itype*)in->data, \
+	                           (ttype*)&not_really_used, \
+	                           (otype*)out->data, \
+	                           nelement, \
+	                           GunpackFunctor<itype,ttype>(byteswap, \
+	                                                       align_msb, \
+	                                                       conjugate), \
+	                           (cudaStream_t)0)
+
+#endif
+	
 	if( out->dtype == BF_DTYPE_I8 ||
 	           out->dtype == BF_DTYPE_CI8 ) {
 	//case BF_DTYPE_I8: {
 		switch( in->dtype ) {
-		// TODO: Work out how to properly deal with 1-bit
-		//case BF_DTYPE_CI1: nelement *= 2;
-		//case BF_DTYPE_I1: {
-		//	BF_ASSERT(nelement % 8 == 0, BF_STATUS_INVALID_SHAPE);
-		//	nelement /= 8;
-		//	CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int64_t); break;
-		//}
+		case BF_DTYPE_CI1: nelement *= 2;
+		case BF_DTYPE_I1: {
+			BF_ASSERT(nelement % 8 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 8;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_SIMPLE_GPU_UNPACK(uint8_t,int64_t);
+			} else {
+				CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int64_t);
+			}
+#else
+			CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int64_t);
+#endif
+		}
 		case BF_DTYPE_CI2: nelement *= 2;
 		case BF_DTYPE_I2: {
 			BF_ASSERT(nelement % 4 == 0, BF_STATUS_INVALID_SHAPE);
 			nelement /= 4;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_SIMPLE_GPU_UNPACK(uint8_t,int32_t);
+			} else {
+				CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int32_t);
+			}
+#else
 			CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int32_t);
+#endif
 			break;
 		}
 		case BF_DTYPE_CI4: nelement *= 2;
 		case BF_DTYPE_I4: {
 			BF_ASSERT(nelement % 2 == 0, BF_STATUS_INVALID_SHAPE);
 			nelement /= 2;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_SIMPLE_GPU_UNPACK(uint8_t,int16_t);
+			} else {
+				CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int16_t);
+			}
+#else
 			CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,int16_t);
+#endif
 			break;
 		}
 		//case BF_DTYPE_U1: {
@@ -290,20 +379,144 @@ BFstatus bfUnpack(BFarray const* in,
 		case BF_DTYPE_U2: {
 			BF_ASSERT(nelement % 4 == 0, BF_STATUS_INVALID_SHAPE);
 			nelement /= 4;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_SIMPLE_GPU_UNPACK(uint8_t,uint32_t);
+			} else {
+				CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,uint32_t);
+			}
+#else
 			CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,uint32_t);
+#endif
 			break;
 		}
 		case BF_DTYPE_U4: {
 			BF_ASSERT(nelement % 2 == 0, BF_STATUS_INVALID_SHAPE);
 			nelement /= 2;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_SIMPLE_GPU_UNPACK(uint8_t,uint16_t);
+			} else {
+				CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,uint16_t);
+			}
+#else
 			CALL_FOREACH_SIMPLE_CPU_UNPACK(uint8_t,uint16_t);
+#endif
 			break;
 		}
 		default: BF_FAIL("Supported bfUnpack input dtype", BF_STATUS_UNSUPPORTED_DTYPE);
 		}
+		
+	} else if( out->dtype == BF_DTYPE_F32 ||
+	           out->dtype == BF_DTYPE_CF32 ) {
+	//case BF_DTYPE_I8: {
+		switch( in->dtype ) {
+		case BF_DTYPE_CI1: nelement *= 2;
+		case BF_DTYPE_I1: {
+			BF_ASSERT(nelement % 8 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 8;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int64_t,float);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int64_t,float);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int64_t,float);
+#endif
+		}
+		case BF_DTYPE_CI2: nelement *= 2;
+		case BF_DTYPE_I2: {
+			BF_ASSERT(nelement % 4 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 4;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int32_t,float);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int32_t,float);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int32_t,float);
+#endif
+			break;
+		}
+		case BF_DTYPE_CI4: nelement *= 2;
+		case BF_DTYPE_I4: {
+			BF_ASSERT(nelement % 2 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 2;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int16_t,float);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int16_t,float);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int16_t,float);
+#endif
+			break;
+		}
+		default: BF_FAIL("Supported bfUnpack input dtype", BF_STATUS_UNSUPPORTED_DTYPE);
+		}
+		
+	} else if( out->dtype == BF_DTYPE_F64 ||
+	           out->dtype == BF_DTYPE_CF64 ) {
+	//case BF_DTYPE_I8: {
+		switch( in->dtype ) {
+		case BF_DTYPE_CI1: nelement *= 2;
+		case BF_DTYPE_I1: {
+			BF_ASSERT(nelement % 8 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 8;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int64_t,double);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int64_t,double);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int64_t,double);
+#endif
+		}
+		case BF_DTYPE_CI2: nelement *= 2;
+		case BF_DTYPE_I2: {
+			BF_ASSERT(nelement % 4 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 4;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int32_t,double);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int32_t,double);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int32_t,double);
+#endif
+			break;
+		}
+		case BF_DTYPE_CI4: nelement *= 2;
+		case BF_DTYPE_I4: {
+			BF_ASSERT(nelement % 2 == 0, BF_STATUS_INVALID_SHAPE);
+			nelement /= 2;
+#ifdef BF_CUDA_ENABLED
+			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				CALL_FOREACH_PROMOTE_GPU_UNPACK(uint8_t,int16_t,double);
+			} else {
+				CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int16_t,double);
+			}
+#else
+			CALL_FOREACH_PROMOTE_CPU_UNPACK(uint8_t,int16_t,double);
+#endif
+			break;
+		}
+		default: BF_FAIL("Supported bfUnpack input dtype", BF_STATUS_UNSUPPORTED_DTYPE);
+		}
+		
 	} else {
 		BF_FAIL("Supported bfUnpack output dtype", BF_STATUS_UNSUPPORTED_DTYPE);
 	}
 #undef CALL_FOREACH_SIMPLE_CPU_UNPACK
+#undef CALL_FOREACH_PROMOTE_CPU_UNPACK
+#ifdef BF_CUDA_ENABLED
+#undef CALL_FOREACH_SIMPLE_GPU_UNPACK
+#undef CALL_FOREACH_PROMOTE_GPU_UNPACK
+#endif
 	return BF_STATUS_SUCCESS;
 }

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -520,3 +520,4 @@ BFstatus bfUnpack(BFarray const* in,
 #endif
 	return BF_STATUS_SUCCESS;
 }
+

--- a/src/utils.hu
+++ b/src/utils.hu
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2017, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017, The University of New Mexico. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BF_UNPACK_GPU_HU_INCLUDE_GUARD_
+#define BF_UNPACK_GPU_HU_INCLUDE_GUARD_
+
+#include <stddef.h>
+#include <stdint.h>
+
+// sign_extend == true  => output has same value as input  (slower)
+// sign_extend == false => output is scaled by 2**(8-nbit) (faster)
+
+template<int NBIT, typename K, typename T>
+inline __device__ void rshift_subwords_gpu(T& val) {
+	for( int k=0; k<(int)(sizeof(T)/sizeof(K)); ++k ) {
+		((K*)&val)[k] >>= NBIT;
+	}
+}
+
+template<typename K, typename T>
+inline __device__ void conjugate_subwords_gpu(T& val) {
+	for( int k=1; k<(int)(sizeof(T)/sizeof(K)); k+=2 ) {
+		K& val_imag = ((K*)&val)[k];
+		val_imag = -val_imag;
+	}
+}
+
+// Simple minimum
+template<typename T, typename U>
+inline __host__ __device__
+T min_gpu(T x, U y) {
+	if( x < y ) {
+		return x;
+	} else {
+		return (T) y;
+	}
+}
+
+// Simple maximum
+template<typename T, typename U>
+inline __host__ __device__
+T max_gpu(T x, U y) {
+	if( x > y ) {
+		return x;
+	} else {
+		return (T) y;
+	}
+}
+
+// Type value limits - maximum
+template<typename T>
+inline __host__ __device__
+T maxval_gpu() {
+	return T(0);
+}
+// Signed
+template<>
+inline __host__ __device__
+int8_t maxval_gpu() {
+	return (int8_t) 127;
+}
+template<>
+inline __host__ __device__
+int16_t maxval_gpu() {
+	return (int16_t) 32767;
+}
+template<>
+inline __host__ __device__
+int32_t maxval_gpu() {
+	return (int32_t) 2147483647;
+}
+template<>
+inline __host__ __device__
+int64_t maxval_gpu() {
+	return (int64_t) 9223372036854775807LL;
+}
+// Unsigned
+template<>
+inline __host__ __device__
+uint8_t maxval_gpu() {
+	return (uint8_t) 255;
+}
+template<>
+inline __host__ __device__
+uint16_t maxval_gpu() {
+	return (uint16_t) 65535;
+}
+template<>
+inline __host__ __device__
+uint32_t maxval_gpu() {
+	return (uint32_t) 4294967295;
+}
+template<>
+inline __host__ __device__
+uint64_t maxval_gpu() {
+	return (uint64_t) 18446744073709551615LL;
+}
+
+// Type value limits - minimum
+template<typename T>
+inline __host__ __device__
+T minval_gpu() {
+	return -maxval_gpu<T>();
+}
+// Unsigned
+template<>
+inline __host__ __device__
+uint8_t minval_gpu() {
+	return (uint8_t) 0;
+}
+template<>
+inline __host__ __device__
+uint16_t minval_gpu() {
+	return (uint16_t) 0;
+}
+template<>
+inline __host__ __device__
+uint32_t minval_gpu() {
+	return (uint32_t) 0;
+}
+template<>
+inline __host__ __device__
+uint64_t minval_gpu() {
+	return (uint64_t) 0;
+}
+
+inline __host__ __device__
+void byteswap_impl_gpu(uint64_t value, uint64_t* result) {
+	*result =
+		((value & 0xFF00000000000000u) >> 56u) |
+		((value & 0x00FF000000000000u) >> 40u) |
+		((value & 0x0000FF0000000000u) >> 24u) |
+		((value & 0x000000FF00000000u) >>  8u) |
+		((value & 0x00000000FF000000u) <<  8u) |
+		((value & 0x0000000000FF0000u) << 24u) |
+		((value & 0x000000000000FF00u) << 40u) |
+		((value & 0x00000000000000FFu) << 56u);
+}
+
+inline __host__ __device__
+void byteswap_impl_gpu(uint32_t value, uint32_t* result) {
+	*result =
+		((value & 0xFF000000u) >> 24u) |
+		((value & 0x00FF0000u) >>  8u) |
+		((value & 0x0000FF00u) <<  8u) |
+		((value & 0x000000FFu) << 24u);
+}
+
+inline __host__ __device__
+void byteswap_impl_gpu(uint16_t value, uint16_t* result) {
+	*result =
+		((value & 0xFF00u) >> 8u) |
+		((value & 0x00FFu) << 8u);
+}
+
+template<typename T, typename U>
+inline __host__ __device__
+T type_pun_gpu(U x) {
+	union {
+		T t;
+		U u;
+	} punner;
+	punner.u = x;
+	return punner.t;
+}
+
+// Byte swapping functions
+template<typename T>
+inline __host__ __device__
+void byteswap_gpu(T value, T* result) {
+	*result = value;
+}
+// 64-bit
+template<>
+inline __host__ __device__
+void byteswap_gpu(uint64_t value, uint64_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint64_t*)result);
+}
+template<>
+inline __host__ __device__
+void byteswap_gpu(int64_t value, int64_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint64_t*)result);
+}
+template<>
+inline __host__ __device__
+void byteswap_gpu(double value, double* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint64_t*)result);
+}
+// 32-bit
+template<>
+inline __host__ __device__
+void byteswap_gpu(uint32_t value, uint32_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint32_t*)result);
+}
+template<>
+inline __host__ __device__
+void byteswap_gpu(int32_t value, int32_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint32_t*)result);
+}
+template<>
+inline __host__ __device__
+void byteswap_gpu(float value, float* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint32_t*)result);
+}
+// 16-bit
+template<>
+inline __host__ __device__
+void byteswap_gpu(uint16_t value, uint16_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint16_t*)result);
+}
+inline __host__ __device__
+void byteswap_gpu(int16_t value, int16_t* result) {
+	return byteswap_impl_gpu(type_pun_gpu<uint64_t>(value), (uint16_t*)result);
+}
+
+#endif // BF_UNPACK_GPU_HU_INCLUDE_GUARD_

--- a/test/test_guantize.py
+++ b/test/test_guantize.py
@@ -1,0 +1,52 @@
+
+# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of The Bifrost Authors nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import numpy as np
+import bifrost as bf
+import bifrost.quantize
+
+class QuantizeTest(unittest.TestCase):
+    def run_quantize_from_cf32_test(self, out_dtype):
+        iarray = bf.ndarray([[0.4 + 0.5j, 1.4 + 1.5j],
+                             [2.4 + 2.5j, 3.4 + 3.5j],
+                             [4.4 + 4.5j, 5.4 + 5.5j]],
+                            dtype='cf32')
+        oarray = bf.ndarray(shape=iarray.shape, dtype=out_dtype, space='cuda')
+        oarray_known = bf.ndarray([[(0,0), (1,2)],
+                                   [(2,2), (3,4)],
+                                   [(4,4), (5,6)]],
+                                  dtype=out_dtype)
+        bf.quantize.quantize(iarray.copy(space='cuda'), oarray)
+        oarray = oarray.copy(space='system')
+        np.testing.assert_equal(oarray, oarray_known)
+    def test_cf32_to_ci8(self):
+        self.run_quantize_from_cf32_test('ci8')
+    def test_cf32_to_ci16(self):
+        self.run_quantize_from_cf32_test('ci16')
+    def test_cf32_to_ci32(self):
+        self.run_quantize_from_cf32_test('ci32')

--- a/test/test_gunpack.py
+++ b/test/test_gunpack.py
@@ -32,12 +32,13 @@ import bifrost.unpack
 
 class UnpackTest(unittest.TestCase):
     def run_unpack_to_ci8_test(self, iarray):
-        oarray = bf.ndarray(shape=iarray.shape, dtype='ci8')
+        oarray = bf.ndarray(shape=iarray.shape, dtype='ci8', space='cuda')
         oarray_known = bf.ndarray([[(0, 1), (2, 3)],
                                    [(4, 5), (6, 7)],
                                    [(-8, -7), (-6, -5)]],
                                   dtype='ci8')
-        bf.unpack.unpack(iarray, oarray)
+        bf.unpack.unpack(iarray.copy(space='cuda'), oarray)
+        oarray = oarray.copy(space='system')
         np.testing.assert_equal(oarray, oarray_known)
     def test_ci4_to_ci8(self):
         iarray = bf.ndarray([[(0x10,),(0x32,)],
@@ -65,12 +66,13 @@ class UnpackTest(unittest.TestCase):
         self.run_unpack_to_ci8_test(iarray.byteswap().conj())
         
     def run_unpack_to_cf32_test(self, iarray):
-        oarray = bf.ndarray(shape=iarray.shape, dtype='cf32')
+        oarray = bf.ndarray(shape=iarray.shape, dtype='cf32', space='cuda')
         oarray_known = bf.ndarray([[ 0+1j,  2+3j],
                                    [ 4+5j,  6+7j],
                                    [-8-7j, -6-5j]],
                                   dtype='cf32')
-        bf.unpack.unpack(iarray, oarray)
+        bf.unpack.unpack(iarray.copy(space='cuda'), oarray)
+        oarray = oarray.copy(space='system')
         np.testing.assert_equal(oarray, oarray_known)
     def test_ci4_to_cf32(self):
         iarray = bf.ndarray([[(0x10,),(0x32,)],

--- a/test/test_resizing.py
+++ b/test/test_resizing.py
@@ -61,6 +61,7 @@ class ModResizeAsciiBlock(SinkBlock):
         span = span_generator.next()
         text_file = open(self.filename, 'a')
         np.savetxt(text_file, span.data_view(np.float32).reshape((1,-1)))
+        text_file.close()
 
 class TestLateResize(unittest.TestCase):
     """Test late resizing of a ring in a pipeline"""


### PR DESCRIPTION
Add support for GPU-based unpacking and quantization (fourth attempt). This includes:
* GPU functions for unpacking integer data into 'i8'/'ci8'
* Functions to unpack integer data and promote to float/double
* Support for unpacking 1-bit data as:
  * 0 unpacks to -1
  * 1 unpacks to 1
* Preliminary support for packing into 'i2'/'ci2' and 'i1'/'ci1'. Full support held up by a check for padded arrays.