### PR TITLE
Multi-logging fixes

### DIFF
--- a/src/proclog.cpp
+++ b/src/proclog.cpp
@@ -167,12 +167,19 @@ public:
 	std::string create_log(std::string name) {
 		std::lock_guard<std::mutex> lock(_mutex);
 		std::string origname = name;
-		int i = 1;
-		while( _logs.count(name) ) {
-			// Disambiguate by adding suffix to name
-			name = origname + "_" + std::to_string(++i);
-		}
+		std::string modname = name.substr(0, name.find("/"));
+		std::string logname = name.substr(name.find("/"), name.length());
 		std::string filename = _logdir + "/" + name;
+		
+		int i = 1;
+		while( _logs.count(filename) ) {
+			// Disambiguate by adding suffix to name
+			name = modname + "_" + std::to_string(++i);
+			if( logname.length() > 0 ) {
+				name = name + "/" + logname;
+			}
+			filename = _logdir + "/" + name;
+		}
 		_logs.insert(filename);
 		return filename;
 	}

--- a/src/proclog.cpp
+++ b/src/proclog.cpp
@@ -116,8 +116,10 @@ class ProcLogMgr {
 			while( (ep = readdir(dp)) ) {
 				pid_t pid = atoi(ep->d_name);
 				if( pid && !process_exists(pid) ) {
-					remove_all(std::string(base_logdir) + "/" +
-					           std::to_string(pid));
+					try {
+						remove_all(std::string(base_logdir) + "/" +
+							   std::to_string(pid));
+					} catch( std::exception ) {}
 				}
 			}
 			closedir(dp);

--- a/tools/like_bmon.py
+++ b/tools/like_bmon.py
@@ -216,14 +216,14 @@ def _getStatistics(blockList, prevList):
             output[pid]['tx' ] = {'good':0, 'missing':0, 'invalid':0, 'late':0, 'drate':0.0, 'prate':0.0, 'gloss':0.0, 'closs':0.0}
             output[pid]['cmd'] = _getCommandLine(pid)
         ### Actual data
-        output[pid][type]['good'   ] = curr['good'   ]
-        output[pid][type]['missing'] = curr['missing']
-        output[pid][type]['invalid'] = curr['invalid']
-        output[pid][type]['late'   ] = curr['late'   ]
-        output[pid][type]['drate'  ] = max([0.0, drate])
-        output[pid][type]['prate'  ] = max([0.0, prate])
-        output[pid][type]['gloss'  ] = max([0.0, min([gloss, 100.0])])
-        output[pid][type]['closs'  ] = max([0.0, min([closs, 100.0])])
+        output[pid][type]['good'   ] += curr['good'   ]
+        output[pid][type]['missing'] += curr['missing']
+        output[pid][type]['invalid'] += curr['invalid']
+        output[pid][type]['late'   ] += curr['late'   ]
+        output[pid][type]['drate'  ] += max([0.0, drate])
+        output[pid][type]['prate'  ] += max([0.0, prate])
+        output[pid][type]['gloss'  ] = max([output[pid][type]['gloss'  ], min([gloss, 100.0])])
+        output[pid][type]['closs'  ] = max([output[pid][type]['closs'  ], min([closs, 100.0])])
 
     # Done
     return output


### PR DESCRIPTION
A couple of fixes for the ProcLog module.  The first is to wrap the `/dev/shm/bifrost/` directory cleanup in a try...catch block to deal with files owned by other users and their pipelines.  The second is a change to the ProcLog name de-duplicator to make it work with the `module/file` structure that is currently used so that duplicate modules use separate directories.