### PR TITLE
Quantize/unpack stream fix

### DIFF
--- a/src/quantize.cpp
+++ b/src/quantize.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 
 #ifdef BF_CUDA_ENABLED
+#include "cuda.hpp"
 #include <guantize.hu>
 #endif
 
@@ -285,7 +286,7 @@ BFstatus bfQuantize(BFarray const* in,
 	                          nelement, \
 	                          GuantizeFunctor<itype,stype,otype> \
 	                          (scale,byteswap_in,byteswap_out), \
-	                          (cudaStream_t)0)
+	                          g_cuda_stream)
 #endif
 	
 	// **TODO: Need CF32 --> CI* separately to support conjugation
@@ -302,7 +303,7 @@ BFstatus bfQuantize(BFarray const* in,
 				                               nelement, \
 				                               GuantizeFunctor<float,float,uint8_t> \
 				                               (scale,byteswap_in,byteswap_out), \
-				                               (cudaStream_t)0);
+				                               g_cuda_stream);
 			} else {
 				foreach_simple_cpu_1bit((float*)in->data, \
 				                        (int8_t*)out->data, \
@@ -329,7 +330,7 @@ BFstatus bfQuantize(BFarray const* in,
 				                               nelement, \
 				                               GuantizeFunctor<float,float,uint8_t> \
 				                               (scale,byteswap_in,byteswap_out), \
-				                               (cudaStream_t)0);
+				                               g_cuda_stream);
 			} else {
 				foreach_simple_cpu_2bit((float*)in->data, \
 				                        (int8_t*)out->data, \
@@ -356,7 +357,7 @@ BFstatus bfQuantize(BFarray const* in,
 				                               nelement, \
 				                               GuantizeFunctor<float,float,uint8_t> \
 				                               (scale,byteswap_in,byteswap_out), \
-				                               (cudaStream_t)0);
+				                               g_cuda_stream);
 			} else {
 				foreach_simple_cpu_4bit((float*)in->data, \
 				                        (int8_t*)out->data, \

--- a/src/quantize.cpp
+++ b/src/quantize.cpp
@@ -36,6 +36,7 @@
 
 #ifdef BF_CUDA_ENABLED
 #include "cuda.hpp"
+#include "trace.hpp"
 #include <guantize.hu>
 #endif
 
@@ -281,12 +282,16 @@ BFstatus bfQuantize(BFarray const* in,
 	
 #ifdef BF_CUDA_ENABLED
 #define CALL_FOREACH_SIMPLE_GPU_QUANTIZE(itype,stype,otype) \
+	{ \
+	BF_TRACE(); \
+	BF_TRACE_STREAM(g_cuda_stream); \
 	launch_foreach_simple_gpu((itype*)in->data, \
 	                          (otype*)out->data, \
 	                          nelement, \
 	                          GuantizeFunctor<itype,stype,otype> \
 	                          (scale,byteswap_in,byteswap_out), \
-	                          g_cuda_stream)
+	                          g_cuda_stream); \
+	} while(0)
 #endif
 	
 	// **TODO: Need CF32 --> CI* separately to support conjugation
@@ -298,6 +303,8 @@ BFstatus bfQuantize(BFarray const* in,
 			BF_ASSERT(nelement % 8 == 0, BF_STATUS_INVALID_SHAPE);
 #ifdef BF_CUDA_ENABLED
 			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				BF_TRACE();
+				BF_TRACE_STREAM(g_cuda_stream);
 				launch_foreach_simple_gpu_1bit((float*)in->data, \
 				                               (int8_t*)out->data, \
 				                               nelement, \
@@ -325,6 +332,8 @@ BFstatus bfQuantize(BFarray const* in,
 			BF_ASSERT(nelement % 4 == 0, BF_STATUS_INVALID_SHAPE);
 #ifdef BF_CUDA_ENABLED
 			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				BF_TRACE();
+				BF_TRACE_STREAM(g_cuda_stream);
 				launch_foreach_simple_gpu_2bit((float*)in->data, \
 				                               (int8_t*)out->data, \
 				                               nelement, \
@@ -352,6 +361,8 @@ BFstatus bfQuantize(BFarray const* in,
 			BF_ASSERT(nelement % 2 == 0, BF_STATUS_INVALID_SHAPE);
 #ifdef BF_CUDA_ENABLED
 			if( space_accessible_from(in->space, BF_SPACE_CUDA) ) {
+				BF_TRACE();
+				BF_TRACE_STREAM(g_cuda_stream);
 				launch_foreach_simple_gpu_4bit((float*)in->data, \
 				                               (int8_t*)out->data, \
 				                               nelement, \

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -30,6 +30,7 @@
 #include "utils.hpp"
 
 #ifdef BF_CUDA_ENABLED
+#include "cuda.hpp"
 #include <gunpack.hu>
 #endif
 
@@ -311,7 +312,7 @@ BFstatus bfUnpack(BFarray const* in,
 	                          GunpackFunctor<itype,otype>(byteswap, \
 	                                                      align_msb, \
 	                                                      conjugate), \
-	                          (cudaStream_t)0)
+	                          g_cuda_stream)
 	                          
 #define CALL_FOREACH_PROMOTE_GPU_UNPACK(itype,ttype,otype) \
 	launch_foreach_promote_gpu((itype*)in->data, \
@@ -321,7 +322,7 @@ BFstatus bfUnpack(BFarray const* in,
 	                           GunpackFunctor<itype,ttype>(byteswap, \
 	                                                       align_msb, \
 	                                                       conjugate), \
-	                           (cudaStream_t)0)
+	                           g_cuda_stream)
 
 #endif
 	

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -31,6 +31,7 @@
 
 #ifdef BF_CUDA_ENABLED
 #include "cuda.hpp"
+#include "trace.hpp"
 #include <gunpack.hu>
 #endif
 
@@ -306,15 +307,22 @@ BFstatus bfUnpack(BFarray const* in,
 	                                              
 #ifdef BF_CUDA_ENABLED
 #define CALL_FOREACH_SIMPLE_GPU_UNPACK(itype,otype) \
+	{ \
+	BF_TRACE(); \
+	BF_TRACE_STREAM(g_cuda_stream); \
 	launch_foreach_simple_gpu((itype*)in->data, \
 	                          (otype*)out->data, \
 	                          nelement, \
 	                          GunpackFunctor<itype,otype>(byteswap, \
 	                                                      align_msb, \
 	                                                      conjugate), \
-	                          g_cuda_stream)
+	                          g_cuda_stream); \
+	} while(0)
 	                          
 #define CALL_FOREACH_PROMOTE_GPU_UNPACK(itype,ttype,otype) \
+	{ \
+	BF_TRACE(); \
+	BF_TRACE_STREAM(g_cuda_stream); \
 	launch_foreach_promote_gpu((itype*)in->data, \
 	                           (ttype*)&not_really_used, \
 	                           (otype*)out->data, \
@@ -322,7 +330,8 @@ BFstatus bfUnpack(BFarray const* in,
 	                           GunpackFunctor<itype,ttype>(byteswap, \
 	                                                       align_msb, \
 	                                                       conjugate), \
-	                           g_cuda_stream)
+	                           g_cuda_stream); \
+	} while(0)
 
 #endif
 	


### PR DESCRIPTION
Updated the GPU versions of quantize and unpack so that they run in `g_cuda_stream` instead of the default stream.  Also, enabled BF_TRACE and BF_TRACE_STREAM in these two modules where relevant.