### PR TITLE
Minor Docker Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 jobs:
     include:
         - stage: docker and deploy docs
-          python: 2.7
+          python: 3.6
           script:
             - make docker-cpu
             - make docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 jobs:
     include:
         - stage: docker and deploy docs
-          python: 3.6
+          python: 2.7
           script:
             - make docker-cpu
             - make docker

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -8,18 +8,13 @@ ENV TERM xterm
 
 # Get dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        python-pip \
         pylint \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Alias - ugly
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 # Update ctypesgen
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    rm get-pip.py
 RUN pip --no-cache-dir install \
         git+https://github.com/olsonse/ctypesgen.git@9bd2d249aa4011c6383a10890ec6f203d7b7990f
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Update ctypesgen
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
+    python3 get-pip.py && \
     rm get-pip.py
 RUN pip --no-cache-dir install \
         git+https://github.com/olsonse/ctypesgen.git@9bd2d249aa4011c6383a10890ec6f203d7b7990f

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Alias - ugly
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 # Update ctypesgen
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -11,9 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         pkg-config \
         software-properties-common \
-        python3 \
-        python3-dev \
-        pylint3 \
+        python \
+        python-dev \
+        python-pip \
+        pylint \
         doxygen \
         exuberant-ctags \
         nano \
@@ -22,12 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Alias - ugly
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    rm get-pip.py
 RUN pip --no-cache-dir install \
         setuptools \
         numpy \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Alias - ugly
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         pkg-config \
         software-properties-common \
-        python \
-        python-dev \
-        pylint \
+        python3 \
+        python3-dev \
+        pylint3 \
         doxygen \
         exuberant-ctags \
         nano \
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
+    python3 get-pip.py && \
     rm get-pip.py
 RUN pip --no-cache-dir install \
         setuptools \

--- a/Dockerfile_prereq.gpu
+++ b/Dockerfile_prereq.gpu
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         pkg-config \
         software-properties-common \
-        python \
-        python-dev \
+        python3 \
+        python3-dev \
         doxygen \
         exuberant-ctags \
         nano \
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
+    python3 get-pip.py && \
     rm get-pip.py
 RUN pip --no-cache-dir install \
         setuptools \

--- a/Dockerfile_prereq.gpu
+++ b/Dockerfile_prereq.gpu
@@ -21,6 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Alias - ugly
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py

--- a/Dockerfile_prereq.gpu
+++ b/Dockerfile_prereq.gpu
@@ -11,8 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         pkg-config \
         software-properties-common \
-        python3 \
-        python3-dev \
+        python \
+        python-dev \
+        python-pip \
         doxygen \
         exuberant-ctags \
         nano \
@@ -21,12 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Alias - ugly
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    rm get-pip.py
 RUN pip --no-cache-dir install \
         setuptools \
         numpy \

--- a/test/download_test_data.sh
+++ b/test/download_test_data.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 curl -L -O http://mcranmer.com/data/bf_test_files.tar.gz
+if [[ "$?" != "0" ]]; then
+	curl -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
+fi
 tar xzf bf_test_files.tar.gz
 mv for_test_suite data
 rm bf_test_files.tar.gz


### PR DESCRIPTION
This is a minor update to the Dockerfiles to get around the deprecation of Python2.7 in the pip version from https://bootstrap.pypa.io/get-pip.py  The Dockerfiles now use the Python2.7-friendly version of pip that ships with Ubuntu.