### PR TITLE
Lightweight Telemetry

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - exuberant-ctags
+    before_index:
+      - export NOCUDA=1
+    index:
+      build_command:
+        - make -e libbifrost

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ jobs:
             - make docker-cpu
             - make docker
             - bash ./.travis_deploy_docs.sh
+    allow_failures:
+        - python: 2.7
+        - python: pypy2.7-6.0
 
 script:
     - sudo pip --no-cache-dir install \

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ script:
     - sudo make -j NOCUDA=1
     - sudo make install
     - export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-    - python -c "from bifrost import telemetry; telemetry.disable()"
     - cd test && sudo -E bash ./travis.sh && cd ..
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
     - sudo make -j NOCUDA=1
     - sudo make install
     - export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+    - python -c "from bifrost import telemetry; telemetry.disable()"
     - cd test && sudo -E bash ./travis.sh && cd ..
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+dist: bionic
+
 language: python
 
 python:
@@ -14,6 +16,7 @@ services:
 
 addons:
     apt:
+        update: true
         packages:
             - build-essential
             - curl

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,19 @@
+0.9.1
+ * Fixed a problem with like_bmon.py crashing when there are a large number of pipelines
+ * Added a CHANGELOG file
+
+0.9.0
+ * Added support for Python3
+ * Migrate from getopt to argparse for the scripts in tools
+ * Improve the test suite coverage
+ * Fixed a problem with proclog cleanup on multi-user systems
+ * Added a new bifrost.romein module for gridding data
+
+0.8.0
+ * Switched from PyCLibrary to ctypesgen for Python bindings
+ * Added tutorials for bifrost.map and bifrost.views to the documentation
+ * Switched to pretty print for bifrost.blocks.print_header
+ * Added new benchmarking tests
+ 
+0.7.0
+ * Initial release

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ from bifrost import telemetry
 telemetry.disable()
 ```
 
+or by using the included `bifrost_telemetry.py` script:
+
+```python bifrost_telemetry.py --disable
+```
+
 This command will set a disk-based flag that disables the reporting process.
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ telemetry.disable()
 
 or by using the included `bifrost_telemetry.py` script:
 
-```python bifrost_telemetry.py --disable
+```
+python bifrost_telemetry.py --disable
 ```
 
 This command will set a disk-based flag that disables the reporting process.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ by running
 
 inside the /docs directory.
 
+## Telemetry
+
+By default Bifrost installs with basic Python telemetry enabled in
+order to help inform how the software is used and to help inform future 
+development.  The data collected as part of this consist seven things:
+ * a timestamp for when the report is generated,
+ * a unique installation identifier,
+ * the Bifrost version being used, 
+ * the execution time of the Python process that imports Bifrost,
+ * which Bifrost modules are imported,
+ * which Bifrost functions are used and their average execution times, and
+ * which Bifrost scripts are used.
+These data are sent to the Bifrost developers using a HTTP POST request where
+they are aggregated.
+
+Users can opt out of telemetry collection using:
+
+```python
+from bifrost import telemetry
+telemetry.disable()
+```
+
+This command will set a disk-based flag that disables the reporting process.
+
 ## Contributors
 
  * Ben Barsdell

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | **`CPU build`** | **`GPU build`** | **`Coverage`** | 
 |-----------------|-----------------|----------------|
-|[![Travis](https://travis-ci.org/ledatelescope/bifrost.svg?branch=master)](https://travis-ci.org/ledatelescope/bifrost) | [![Build Status](https://fornax.phys.unm.edu/jenkins/buildStatus/icon?job=Bifrost)](https://fornax.phys.unm.edu/jenkins/job/Bifrost/) | [![Coverage Status](https://coveralls.io/repos/github/ledatelescope/bifrost/badge.svg)](https://coveralls.io/github/ledatelescope/bifrost) |
+|[![Travis](https://travis-ci.com/ledatelescope/bifrost.svg?branch=master)](https://travis-ci.com/ledatelescope/bifrost) | [![Build Status](https://fornax.phys.unm.edu/jenkins/buildStatus/icon?job=Bifrost)](https://fornax.phys.unm.edu/jenkins/job/Bifrost/) | [![Coverage Status](https://coveralls.io/repos/github/ledatelescope/bifrost/badge.svg)](https://coveralls.io/github/ledatelescope/bifrost) |
 
 A stream processing framework for high-throughput applications.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bifrost
 
-| **`CPU build`** | **`Coverage`** | 
-|----------------------|----------------------|
-|[![Travis](https://travis-ci.org/ledatelescope/bifrost.svg?branch=master)](https://travis-ci.org/ledatelescope/bifrost) | [![Coverage Status](https://coveralls.io/repos/github/ledatelescope/bifrost/badge.svg)](https://coveralls.io/github/ledatelescope/bifrost) |
+| **`CPU build`** | **`GPU build`** | **`Coverage`** | 
+|-----------------|-----------------|----------------|
+|[![Travis](https://travis-ci.org/ledatelescope/bifrost.svg?branch=master)](https://travis-ci.org/ledatelescope/bifrost) | [![Build Status](https://fornax.phys.unm.edu/jenkins/buildStatus/icon?job=Bifrost)](https://fornax.phys.unm.edu/jenkins/job/Bifrost/) | [![Coverage Status](https://coveralls.io/repos/github/ledatelescope/bifrost/badge.svg)](https://coveralls.io/github/ledatelescope/bifrost) |
 
 A stream processing framework for high-throughput applications.
 

--- a/python/bifrost/DataType.py
+++ b/python/bifrost/DataType.py
@@ -49,6 +49,9 @@ if sys.version_info < (3,):
 from bifrost.libbifrost import _bf
 import numpy as np
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # Custom dtypes to represent additional complex types
 # Note: These can be constructed using tuples
 #   E.g., np.ndarray([(0x10,), (0x32,)], dtype=ci4) # Special case

--- a/python/bifrost/GPUArray.py
+++ b/python/bifrost/GPUArray.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 # Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,10 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ctypes
 import numpy as np
 from bifrost.memory import raw_malloc, raw_free, memset, memcpy, memcpy2D
-from bifrost.libbifrost import _bf, _check, _string2space
 from bifrost.array import _array2bifrost # This doesn't exist!
 
 class GPUArray(object):

--- a/python/bifrost/GPUArray.py
+++ b/python/bifrost/GPUArray.py
@@ -30,6 +30,9 @@ import numpy as np
 from bifrost.memory import raw_malloc, raw_free, memset, memcpy, memcpy2D
 from bifrost.array import _array2bifrost # This doesn't exist!
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class GPUArray(object):
     def __init__(self, shape, dtype, buffer=None, offset=0, strides=None):
         itemsize = dtype().itemsize

--- a/python/bifrost/Space.py
+++ b/python/bifrost/Space.py
@@ -27,6 +27,9 @@
 
 from bifrost.libbifrost import _bf
 
+from bifrost import telemetry
+telemetry.track_module()
+
 SPACEMAP_TO_STR = {_bf.BF_SPACE_AUTO:         'auto',
                    _bf.BF_SPACE_SYSTEM:       'system',
                    _bf.BF_SPACE_CUDA:         'cuda',

--- a/python/bifrost/addon/leda/bandfiles.py
+++ b/python/bifrost/addon/leda/bandfiles.py
@@ -31,6 +31,9 @@ import os, sys
 sys.path.append('..')
 import make_header
 
+from bifrost import telemetry
+telemetry.track_module()
+
 disk_names = [ "ledastorage", "longterm", "offsite", "data" ]
 ledaovro_names = [ "ledaovro1", "ledaovro2", "ledaovro3", "ledaovro4", "ledaovro5", "ledaovro6", "ledaovro7", "ledaovro8", "ledaovro9", "ledaovro10", "ledaovro11","ledaovro12" ]
 data_names = [ "data1", "data2" ]
@@ -197,4 +200,3 @@ class BandFiles(object):
     for f in self.files:
       if f.freq in frequencies: has.append(f.freq)
     return has
-

--- a/python/bifrost/addon/leda/blocks.py
+++ b/python/bifrost/addon/leda/blocks.py
@@ -42,6 +42,8 @@ import json
 import numpy as np
 from bifrost import block
 
+from bifrost import telemetry
+telemetry.track_module()
 
 # Read a collection of DADA files and form an array of time series data over
 # many frequencies.

--- a/python/bifrost/addon/leda/make_header.py
+++ b/python/bifrost/addon/leda/make_header.py
@@ -1,7 +1,5 @@
 
-
-
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,9 +40,9 @@ import numpy as np
 import os, sys, ephem, datetime
 from dateutil import tz
 
-
 class DadaReader(object):
-    """ Dada file reader for raw LEDA correlator data.
+    """
+    Dada file reader for raw LEDA correlator data.
 
     Reads the header of a dada file 
 
@@ -61,10 +59,10 @@ class DadaReader(object):
 
     def __init__(self, filename, warnings, file_size):
         self.filename = filename
-    self.warnings = warnings
-     self.file_size = file_size    # Externally supplied
-    #print(filename, warnings, file_size)
-    self.generate_info()
+        self.warnings = warnings
+        self.file_size = file_size    # Externally supplied
+        #print(filename, warnings, file_size)
+        self.generate_info()
 
     def generate_info(self):
         """ Parse dada header and form useful quantities. Calculate everything that can be calculated 
@@ -73,7 +71,7 @@ class DadaReader(object):
 
         f = open(self.filename, 'rb')
         headerstr = f.read(self.DEFAULT_HEADER_SIZE)
-    f.close()
+        f.close()
 
         header = {}
         for line in headerstr.split('\n'):
@@ -85,206 +83,219 @@ class DadaReader(object):
             value = value.strip()
             header[key] = value
 
-    self.source = header["SOURCE"]
+        self.source = header["SOURCE"]
         self.mode = header['MODE']    
-    if "UTC_START" in header: self.datestamp = header['UTC_START']
-        else: self.datestamp = "UNKNOWN"
-        if "CFREQ" in header: self.c_freq_mhz = float(header['CFREQ'])
-        else: self.c_freq_mhz = "UNKNOWN"
-        if "BW" in header: self.bandwidth_mhz  = float(header['BW'])
-        else: self.bandwidth_mhz = "UNKNOWN"
-        if "NCHAN" in header: self.n_chans = int(header["NCHAN"])
-    else: self.n_chans = "UNKNOWN"
-    if "DATA_ORDER" in header: self.data_order = header["DATA_ORDER"]
-    else: self.data_order = "UNKNOWN"
+        if "UTC_START" in header:
+            self.datestamp = header['UTC_START']
+        else:
+            self.datestamp = "UNKNOWN"
+        if "CFREQ" in header:
+            self.c_freq_mhz = float(header['CFREQ'])
+        else:
+            self.c_freq_mhz = "UNKNOWN"
+        if "BW" in header:
+            self.bandwidth_mhz  = float(header['BW'])
+        else:
+            self.bandwidth_mhz = "UNKNOWN"
+        if "NCHAN" in header:
+            self.n_chans = int(header["NCHAN"])
+        else:
+            self.n_chans = "UNKNOWN"
+        if "DATA_ORDER" in header:
+            self.data_order = header["DATA_ORDER"]
+        else:
+            self.data_order = "UNKNOWN"
 
-    have_size = True    # If we can settle on a file size for the zipped files.
+        have_size = True    # If we can settle on a file size for the zipped files.
 
         # Calculate number of integrations within this file
         # File may not be complete, hence file_size_dsk is read too.
-    # However this is now complicated by zipping files. I am
-    # trying to be clever to figure the size. - HG
+        # However this is now complicated by zipping files. I am
+        # trying to be clever to figure the size. - HG
 
         if self.filename[-8:] == ".dadazip":    # Will not unzip to get actual size. Must be specified somehow.
-      if self.file_size:            # We are given the complete file size which overrides everything else.
-        data_size_dsk = int(self.file_size)-self.DEFAULT_HEADER_SIZE
-        data_size_hdr = data_size_dsk
-      elif "FILE_SIZE" in header:        # Hope that this is right
-        data_size_dsk = int(header["FILE_SIZE"])    # these data sizes don't include header
-        data_size_hdr = data_size_dsk
-      else:                    # Failure
-        if self.warnings: print("WARNING: File is zipped and FILE_SIZE is not in header and file_size not supplied. ")
-        have_size = False
-        data_size_hdr = data_size_dsk = 0
-    else:                     # File not zipped. Can get true complete file size
-      data_size_dsk = os.path.getsize(self.filename)-self.DEFAULT_HEADER_SIZE
-      if "FILE_SIZE" in header: data_size_hdr = int(header["FILE_SIZE"])
-      else: data_size_hdr = data_size_dsk
+            if self.file_size:            # We are given the complete file size which overrides everything else.
+                data_size_dsk = int(self.file_size)-self.DEFAULT_HEADER_SIZE
+                data_size_hdr = data_size_dsk
+            elif "FILE_SIZE" in header:        # Hope that this is right
+                data_size_dsk = int(header["FILE_SIZE"])    # these data sizes don't include header
+                data_size_hdr = data_size_dsk
+            else:                    # Failure
+                if self.warnings:
+                    print("WARNING: File is zipped and FILE_SIZE is not in header and file_size not supplied. ")
+                have_size = False
+                data_size_hdr = data_size_dsk = 0
+        else:                     # File not zipped. Can get true complete file size
+            data_size_dsk = os.path.getsize(self.filename)-self.DEFAULT_HEADER_SIZE
+            if "FILE_SIZE" in header:
+                data_size_hdr = int(header["FILE_SIZE"])
+            else:
+                data_size_hdr = data_size_dsk
 
         if data_size_hdr != data_size_dsk:
-      if self.warnings: print("WARNING: Data size in file doesn't match actual size. Using actual size.")
+            if self.warnings:
+                print("WARNING: Data size in file doesn't match actual size. Using actual size.")
 
-    data_size = data_size_dsk        # Settle on this as the size of the data
+            data_size = data_size_dsk        # Settle on this as the size of the data
 
-    self.file_size = data_size+self.DEFAULT_HEADER_SIZE
+        self.file_size = data_size+self.DEFAULT_HEADER_SIZE
 
-    # Try to be clever and generate values that can be generated, while leaving 
-     # undefined values as UNKNOWN.
+        # Try to be clever and generate values that can be generated, while leaving 
+        # undefined values as UNKNOWN.
         if "BYTES_PER_AVG" in header:
-          bpa = int(header["BYTES_PER_AVG"])
+            bpa = int(header["BYTES_PER_AVG"])
 
         if "BYTES_PER_AVG" in header and have_size:
-       if data_size % bpa != 0:
-        if self.warnings: print("WARNING: BYTES_PER_AVG does not result in an integral number of scans")
+            if data_size % bpa != 0:
+                if self.warnings:
+                    print("WARNING: BYTES_PER_AVG does not result in an integral number of scans")
         if "DATA_ORDER" in header and self.data_order == 'TIME_SUBSET_CHAN_TRIANGULAR_POL_POL_COMPLEX':
-          if self.warnings: 
-        print('DATA_ORDER is TIME_SUBSET_CHAN_TRIANGULAR_POL_POL_COMPLEX, resetting BYTES_PER_AVG to',(109*32896*2*2+9*109*1270*2*2)*8,"(fixed)")
-          bpa = (109*32896*2*2+9*109*1270*2*2)*8
-          if data_size % bpa != 0 and self.warnings:
-            print("WARNING: BYTES_PER_AVG still doesn't give integral number of scans")
+            if self.warnings: 
+                print('DATA_ORDER is TIME_SUBSET_CHAN_TRIANGULAR_POL_POL_COMPLEX, resetting BYTES_PER_AVG to',(109*32896*2*2+9*109*1270*2*2)*8,"(fixed)")
+            bpa = (109*32896*2*2+9*109*1270*2*2)*8
+            if data_size % bpa != 0 and self.warnings:
+                print("WARNING: BYTES_PER_AVG still doesn't give integral number of scans")
 
-          self.n_int = float(data_size) / bpa
+            self.n_int = float(data_size) / bpa
 
-    else: self.n_int = "UNKNOWN"
+        else:
+            self.n_int = "UNKNOWN"
 
-    if "TSAMP" in header and "NAVG" in header:
-          # Calculate integration time per accumulation
-          tsamp      = float(header["TSAMP"]) * 1e-6   # Sampling time per channel, in microseconds
-          navg       = int(header["NAVG"])             # Number of averages per integration
-          int_tim    = tsamp * navg                    # Integration time is tsamp * navg
-          self.t_int = int_tim
+        if "TSAMP" in header and "NAVG" in header:
+            # Calculate integration time per accumulation
+            tsamp      = float(header["TSAMP"]) * 1e-6   # Sampling time per channel, in microseconds
+            navg       = int(header["NAVG"])             # Number of averages per integration
+            int_tim    = tsamp * navg                    # Integration time is tsamp * navg
+            self.t_int = int_tim
 
-      if "OBS_OFFSET" in header and "BYTES_PER_AVG" in header:
-            # Calculate the time offset since the observation started
-            byte_offset = int(header["OBS_OFFSET"])
-            num_int_since_obs_start = byte_offset // bpa  
-            time_offset_since_obs_start = num_int_since_obs_start * int_tim
-            self.t_offset = time_offset_since_obs_start
+            if "OBS_OFFSET" in header and "BYTES_PER_AVG" in header:
+                # Calculate the time offset since the observation started
+                byte_offset = int(header["OBS_OFFSET"])
+                num_int_since_obs_start = byte_offset // bpa  
+                time_offset_since_obs_start = num_int_since_obs_start * int_tim
+                self.t_offset = time_offset_since_obs_start
 
-      else: self.t_offset = "UNKNOWN"    
+            else:
+                self.t_offset = "UNKNOWN"    
 
-    else:
-          self.t_int = "UNKNOWN"
-          self.t_offset = "UNKNOWN"
-
-
+        else:
+              self.t_int = "UNKNOWN"
+              self.t_offset = "UNKNOWN"
 
 class DadaTimes(object):
-  """
+    """
     Handle the generation of true times and RA/DEC for the observation in the DADA file.
     Use pyephem for the tricky stuff. Includes the new calculation of RA/DEC in terms
     of long/lat rather than just using long/lat.
-  """
+    """
 
-  def time_at_timezone(self, dt, zone):
-    from_zone = tz.gettz('UTC')
-    to_zone = tz.gettz(zone)
+    def time_at_timezone(self, dt, zone):
+        from_zone = tz.gettz('UTC')
+        to_zone = tz.gettz(zone)
 
-    # Tell the datetime object that it's in UTC time zone since 
-    # datetime objects are 'naive' by default
-    dt = dt.replace(tzinfo=from_zone)
+        # Tell the datetime object that it's in UTC time zone since 
+        # datetime objects are 'naive' by default
+        dt = dt.replace(tzinfo=from_zone)
 
-    # Convert time zone
-    return dt.astimezone(to_zone)
+        # Convert time zone
+        return dt.astimezone(to_zone)
 
-  def __init__(self, header):
+    def __init__(self, header):
+        ovro = ephem.Observer()
+        (ovro.lat, ovro.lon, ovro.elev) = ('37.23978', '-118.281667', 1184.120)
 
-    ovro = ephem.Observer()
-    (ovro.lat, ovro.lon, ovro.elev) = ('37.23978', '-118.281667', 1184.120)
+        if header.datestamp == "UNKNOWN" or header.t_offset == "UNKNOWN":
+            self.lst = "UNKNOWN"
+            self.date_str = "UNKNOWN"
+            self.time_str = "UNKNOWN"
+            self.localtime_str = "UNKNOWN"
+            self.lst_str = "UNKNOWN"
+            self.dec_str = "UNKNOWN"
+            return
 
-    if header.datestamp == "UNKNOWN" or header.t_offset == "UNKNOWN":
-      self.lst = "UNKNOWN"
-      self.date_str = "UNKNOWN"
-      self.time_str = "UNKNOWN"
-      self.localtime_str = "UNKNOWN"
-      self.lst_str = "UNKNOWN"
-      self.dec_str = "UNKNOWN"
-      return
-
-
-    # Calculate times including LST
-    dt = datetime.datetime.strptime(header.datestamp, "%Y-%m-%d-%H:%M:%S")+datetime.timedelta(seconds=header.t_offset)
-    ovro.date = dt
-    self.lst = ovro.sidereal_time()
-    localt = self.time_at_timezone(dt, "America/Los_Angeles")
-    self.date_str = "%04d%02d%02d"%(dt.year,dt.month,dt.day)
-    self.time_str = "%02d%02d%02d"%(dt.hour,dt.minute,dt.second)
-    self.localtime_str = "%02d%02d%02d"%(localt.hour,localt.minute,localt.second)
-    ra, dec = ovro.radec_of(0, np.pi/2)
-    self.lst_str = str(float(ra) / 2 / np.pi * 24)
-    self.dec_str = str(float(repr(dec))*180/np.pi)
-    #print("UTC START:   %s"%dada_file.datestamp)
-    #print("TIME OFFSET: %s"%datetime.timedelta(seconds=dada_file.t_offset))
-    #print("NEW START:   (%s, %s)"%(date_str, time_str))
-
+        # Calculate times including LST
+        dt = datetime.datetime.strptime(header.datestamp, "%Y-%m-%d-%H:%M:%S")+datetime.timedelta(seconds=header.t_offset)
+        ovro.date = dt
+        self.lst = ovro.sidereal_time()
+        localt = self.time_at_timezone(dt, "America/Los_Angeles")
+        self.date_str = "%04d%02d%02d"%(dt.year,dt.month,dt.day)
+        self.time_str = "%02d%02d%02d"%(dt.hour,dt.minute,dt.second)
+        self.localtime_str = "%02d%02d%02d"%(localt.hour,localt.minute,localt.second)
+        ra, dec = ovro.radec_of(0, np.pi/2)
+        self.lst_str = str(float(ra) / 2 / np.pi * 24)
+        self.dec_str = str(float(repr(dec))*180/np.pi)
+        #print("UTC START:   %s"%dada_file.datestamp)
+        #print("TIME OFFSET: %s"%datetime.timedelta(seconds=dada_file.t_offset))
+        #print("NEW START:   (%s, %s)"%(date_str, time_str))
 
 def make_header(filename, write=True, warn=True, size=None):
-  """
-  Create useful/necessary information about an observation. Used by other programs
-  like corr2uvfits and DuCT.
+    """
+    Create useful/necessary information about an observation. Used by other programs
+    like corr2uvfits and DuCT.
 
-  filename: DADA file, can be zipped
-  warn: print warnings
-  write: write a header.txt files
-  size: specify a true file size in case of zipped file
-  """
+    filename: DADA file, can be zipped
+    warn: print warnings
+    write: write a header.txt files
+    size: specify a true file size in case of zipped file
+    """
 
-  # Get information from the DADA file
-  dada_file = DadaReader(filename, warn, size)
-  dada_times = DadaTimes(dada_file)
+    # Get information from the DADA file
+    dada_file = DadaReader(filename, warn, size)
+    dada_times = DadaTimes(dada_file)
 
+    # Fill and either dump or return header. Slight differences depending on which.
+    header_params = {'N_CHANS'    : dada_file.n_chans,
+                     'N_SCANS'    : dada_file.n_int,
+                     'INT_TIME'   : dada_file.t_int,
+                     'FREQCENT'   : dada_file.c_freq_mhz,
+                     'BANDWIDTH'  : dada_file.bandwidth_mhz,
+                     'RA_HRS'     : dada_times.lst_str,
+                     'DEC_DEGS'   : dada_times.dec_str,
+                     'DATE'       : dada_times.date_str,
+                     'TIME'       : dada_times.time_str,
+                     'LOCALTIME'  : dada_times.localtime_str,
+                     'LST'        : dada_times.lst_str,
+                     'DATA_ORDER' : dada_file.data_order,
+                     'FILE_SIZE'  : dada_file.file_size,
+                     'MODE'       : dada_file.mode,
+                     'TIME_OFFSET': dada_file.t_offset,
+                     'SOURCE'     : dada_file.source
+                    }
 
-  # Fill and either dump or return header. Slight differences depending on which.
-  header_params = {
-    'N_CHANS'    : dada_file.n_chans,
-    'N_SCANS'    : dada_file.n_int,
-    'INT_TIME'   : dada_file.t_int,
-    'FREQCENT'   : dada_file.c_freq_mhz,
-    'BANDWIDTH'  : dada_file.bandwidth_mhz,
-    'RA_HRS'     : dada_times.lst_str,
-    'DEC_DEGS'   : dada_times.dec_str,
-    'DATE'       : dada_times.date_str,
-    'TIME'       : dada_times.time_str,
-        'LOCALTIME'  : dada_times.localtime_str,
-    'LST'         : dada_times.lst_str,
-    'DATA_ORDER' : dada_file.data_order,
-    'FILE_SIZE'  : dada_file.file_size,
-    'MODE'       : dada_file.mode,
-    'TIME_OFFSET': dada_file.t_offset,
-    'SOURCE'     : dada_file.source
-  }
+    if header_params["N_SCANS"] == "UNKNOWN":
+        n_scans = "UNKNOWN"
+    else:
+        n_scans = str(int(header_params['N_SCANS']))
+    if write:    # This format is used by corr2uvfits and DuCT for transforming a DADA file.
+        output = open("header.txt","w")
+        output.write("# Generated by make_header.py\n\n")
+        output.write("FIELDNAME Zenith\n")
+        output.write("N_SCANS   "+n_scans+"\n")
+        output.write("N_INPUTS  512\n")
+        output.write("N_CHANS   "+str(header_params['N_CHANS'])+"      # number of channels in spectrum\n")
+        output.write("CORRTYPE  B             # correlation type to use. 'C'(cross), 'B'(both), or 'A'(auto)\n")
+        output.write("INT_TIME  "+str(header_params['INT_TIME'])+"    # integration time of scan in seconds\n")
+        output.write("FREQCENT  "+str(header_params['FREQCENT'])+"    # observing center freq in MHz\n")
+        output.write("BANDWIDTH "+str(header_params['BANDWIDTH'])+"   # total bandwidth in MHz\n")
+        output.write("# To phase to the zenith, these must be the HA, RA and Dec of the zenith.\n")
+        output.write("HA_HRS    0.000000      # the RA of the desired phase centre (hours)\n")
+        output.write("RA_HRS    "+header_params['RA_HRS']+"      # the RA of the desired phase centre (hours)\n")
+        output.write("DEC_DEGS  "+str(header_params['DEC_DEGS'])+"          # the DEC of the desired phase centre (degs)\n")
+        output.write("DATE      "+header_params['DATE']+"        # YYYYMMDD\n")
+        output.write("TIME      "+header_params['TIME']+"        # HHMMSS\n")
+        output.write("LOCALTIME "+str(dada_times.localtime_str)+"\n")
+        output.write("LST   "+str(dada_times.lst)+"\n")
+        output.write("INVERT_FREQ 0           # 1 if the freq decreases with channel number\n")
+        output.write("CONJUGATE   1           # conjugate the raw data to fix sign convention problem if necessary\n")
+        output.write("GEOM_CORRECT    0\n")
+        output.close()
 
-  if header_params["N_SCANS"] == "UNKNOWN": n_scans = "UNKNOWN"
-  else: n_scans = str(int(header_params['N_SCANS']))
-  if write:    # This format is used by corr2uvfits and DuCT for transforming a DADA file.
-    output = open("header.txt","w")
-    output.write("# Generated by make_header.py\n\n")
-    output.write("FIELDNAME Zenith\n")
-    output.write("N_SCANS   "+n_scans+"\n")
-    output.write("N_INPUTS  512\n")
-    output.write("N_CHANS   "+str(header_params['N_CHANS'])+"      # number of channels in spectrum\n")
-    output.write("CORRTYPE  B             # correlation type to use. 'C'(cross), 'B'(both), or 'A'(auto)\n")
-    output.write("INT_TIME  "+str(header_params['INT_TIME'])+"    # integration time of scan in seconds\n")
-    output.write("FREQCENT  "+str(header_params['FREQCENT'])+"    # observing center freq in MHz\n")
-    output.write("BANDWIDTH "+str(header_params['BANDWIDTH'])+"   # total bandwidth in MHz\n")
-    output.write("# To phase to the zenith, these must be the HA, RA and Dec of the zenith.\n")
-    output.write("HA_HRS    0.000000      # the RA of the desired phase centre (hours)\n")
-    output.write("RA_HRS    "+header_params['RA_HRS']+"      # the RA of the desired phase centre (hours)\n")
-    output.write("DEC_DEGS  "+str(header_params['DEC_DEGS'])+"          # the DEC of the desired phase centre (degs)\n")
-    output.write("DATE      "+header_params['DATE']+"        # YYYYMMDD\n")
-    output.write("TIME      "+header_params['TIME']+"        # HHMMSS\n")
-    output.write("LOCALTIME "+str(dada_times.localtime_str)+"\n")
-    output.write("LST   "+str(dada_times.lst)+"\n")
-    output.write("INVERT_FREQ 0           # 1 if the freq decreases with channel number\n")
-    output.write("CONJUGATE   1           # conjugate the raw data to fix sign convention problem if necessary\n")
-    output.write("GEOM_CORRECT    0\n")
-    output.close()
-
-  return header_params        # If this function is called from other scripts (e.g. plot scripts) it can supply useful information
+    return header_params        # If this function is called from other scripts (e.g. plot scripts) it can supply useful information
 
 if __name__ == "__main__":
-  if len(sys.argv) == 2: make_header(sys.argv[1])
-  elif len(sys.argv) == 3: make_header(sys.argv[1],size=sys.argv[2])
-  else:
-    print("Expecting file name and optionally file size")
-
+    if len(sys.argv) == 2:
+        make_header(sys.argv[1])
+    elif len(sys.argv) == 3:
+        make_header(sys.argv[1],size=sys.argv[2])
+    else:
+        print("Expecting file name and optionally file size")

--- a/python/bifrost/addon/leda/make_header.py
+++ b/python/bifrost/addon/leda/make_header.py
@@ -40,6 +40,9 @@ import numpy as np
 import os, sys, ephem, datetime
 from dateutil import tz
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class DadaReader(object):
     """
     Dada file reader for raw LEDA correlator data.

--- a/python/bifrost/address.py
+++ b/python/bifrost/address.py
@@ -36,6 +36,9 @@ from bifrost.libbifrost import _bf, _check, _get, BifrostObject
 import ctypes
 from socket import AF_UNSPEC
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Address(BifrostObject):
     def __init__(self, address, port, family=None):
         try:

--- a/python/bifrost/affinity.py
+++ b/python/bifrost/affinity.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 
 from bifrost.libbifrost import _bf, _check, _get, _array
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def get_core():
     return _get(_bf.bfAffinityGetCore)
 def set_core(core):

--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -45,7 +45,6 @@ try:
 except ImportError:
     from contextlib2 import ExitStack
 import numpy as np
-import bifrost
 from bifrost import affinity, memory
 from bifrost.ring import Ring
 from bifrost.sigproc import SigprocFile, unpack

--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -49,6 +49,9 @@ from bifrost import affinity, memory
 from bifrost.ring import Ring
 from bifrost.sigproc import SigprocFile, unpack
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Pipeline(object):
     """Class which connects blocks linearly, with
         one ring between each block. Does this by creating

--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ except ImportError:
     from contextlib2 import ExitStack
 import numpy as np
 import bifrost
-from bifrost import affinity
+from bifrost import affinity, memory
 from bifrost.ring import Ring
 from bifrost.sigproc import SigprocFile, unpack
 
@@ -589,7 +589,7 @@ class CopyBlock(TransformBlock):
         input_ring = input_rings[0]
         for output_ring in output_rings:
             for ispan, ospan in self.ring_transfer(input_ring, output_ring):
-                bifrost.memory.memcpy2D(ospan.data, ispan.data)
+                memory.memcpy2D(ospan.data, ispan.data)
 class SigprocReadBlock(SourceBlock):
     """This block reads in a sigproc filterbank
     (.fil) file into a ring buffer"""
@@ -804,7 +804,7 @@ class FoldBlock(TransformBlock):
         self.out_gulp_size = self.bins * 4
         out_span_generator = self.iterate_ring_write(output_rings[0])
         out_span = next(out_span_generator)
-        bifrost.memory.memcpy(
+        memory.memcpy(
             out_span.data_view(dtype=np.float32),
             histogram)
 

--- a/python/bifrost/block_chainer.py
+++ b/python/bifrost/block_chainer.py
@@ -29,6 +29,9 @@ from __future__ import print_function
 
 import bifrost
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class _BlockChainerProxy(object):
     def __init__(self, parent, module):
         self.parent = parent

--- a/python/bifrost/blocks/accumulate.py
+++ b/python/bifrost/blocks/accumulate.py
@@ -37,6 +37,9 @@ from bifrost.pipeline import TransformBlock
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class AccumulateBlock(TransformBlock):
     def __init__(self, iring, nframe, dtype=None, gulp_nframe=1,
              *args, **kwargs):

--- a/python/bifrost/blocks/audio.py
+++ b/python/bifrost/blocks/audio.py
@@ -30,6 +30,9 @@ from __future__ import absolute_import
 from bifrost.pipeline import SourceBlock
 import bifrost.portaudio as audio
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class AudioSourceBlock(SourceBlock):
     def create_reader(self, kwargs):
         self.reader = audio.open(mode='r', **kwargs)

--- a/python/bifrost/blocks/binary_io.py
+++ b/python/bifrost/blocks/binary_io.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,8 +31,6 @@
 Basic file I/O blocks for reading and writing data.
 """
 import numpy as np
-import time
-import bifrost as bf
 import bifrost.pipeline as bfp
 from bifrost.dtype import name_nbit2numpy
 

--- a/python/bifrost/blocks/binary_io.py
+++ b/python/bifrost/blocks/binary_io.py
@@ -34,6 +34,9 @@ import numpy as np
 import bifrost.pipeline as bfp
 from bifrost.dtype import name_nbit2numpy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class BinaryFileRead(object):
     """ Simple file-like reading object for pipeline testing
 

--- a/python/bifrost/blocks/convert_visibilities.py
+++ b/python/bifrost/blocks/convert_visibilities.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 from __future__ import absolute_import
 
 from bifrost.pipeline import TransformBlock
-from bifrost.linalg import LinAlg
 from bifrost.DataType import DataType
 import bifrost as bf
 

--- a/python/bifrost/blocks/convert_visibilities.py
+++ b/python/bifrost/blocks/convert_visibilities.py
@@ -34,6 +34,9 @@ import bifrost as bf
 from copy import deepcopy
 from math import sqrt
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class ConvertVisibilitiesBlock(TransformBlock):
     def __init__(self, iring, fmt,
                  *args, **kwargs):

--- a/python/bifrost/blocks/copy.py
+++ b/python/bifrost/blocks/copy.py
@@ -32,6 +32,9 @@ from bifrost.ndarray import copy_array
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class CopyBlock(TransformBlock):
     def __init__(self, iring, space=None, *args, **kwargs):
         super(CopyBlock, self).__init__(iring, *args, **kwargs)

--- a/python/bifrost/blocks/correlate.py
+++ b/python/bifrost/blocks/correlate.py
@@ -36,6 +36,9 @@ from bifrost.linalg import LinAlg
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class CorrelateBlock(TransformBlock):
     def __init__(self, iring, nframe_per_integration,
                  *args, **kwargs):

--- a/python/bifrost/blocks/detect.py
+++ b/python/bifrost/blocks/detect.py
@@ -37,6 +37,9 @@ from bifrost.DataType import DataType
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class DetectBlock(TransformBlock):
     def __init__(self, iring, mode, axis=None,
                  *args, **kwargs):

--- a/python/bifrost/blocks/fdmt.py
+++ b/python/bifrost/blocks/fdmt.py
@@ -34,6 +34,9 @@ from bifrost.units import convert_units
 from copy import deepcopy
 import math
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class FdmtBlock(TransformBlock):
     def __init__(self, iring, max_dm=None, max_delay=None, max_diagonal=None,
                  exponent=-2.0, negative_delays=False,

--- a/python/bifrost/blocks/fft.py
+++ b/python/bifrost/blocks/fft.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@ from bifrost.units import transform_units
 from bifrost.DataType import DataType
 
 from copy import deepcopy
-import math
 
 class FftBlock(TransformBlock):
     # TODO: Add support for sizes (aka 's') parameter that defines transform

--- a/python/bifrost/blocks/fft.py
+++ b/python/bifrost/blocks/fft.py
@@ -34,6 +34,9 @@ from bifrost.DataType import DataType
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class FftBlock(TransformBlock):
     # TODO: Add support for sizes (aka 's') parameter that defines transform
     #         length in each dimension (i.e., cropped/padded transforms).

--- a/python/bifrost/blocks/fftshift.py
+++ b/python/bifrost/blocks/fftshift.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@ if sys.version_info < (3,):
     
 import bifrost as bf
 from bifrost.pipeline import TransformBlock
-from bifrost.DataType import DataType
 
 from copy import deepcopy
 

--- a/python/bifrost/blocks/fftshift.py
+++ b/python/bifrost/blocks/fftshift.py
@@ -36,6 +36,9 @@ from bifrost.pipeline import TransformBlock
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class FftShiftBlock(TransformBlock):
     def __init__(self, iring, axes, inverse=False,
                  *args, **kwargs):

--- a/python/bifrost/blocks/guppi_raw.py
+++ b/python/bifrost/blocks/guppi_raw.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,8 +29,6 @@ from __future__ import absolute_import
 
 from bifrost.pipeline import SourceBlock
 import bifrost.guppi_raw as guppi_raw
-
-import numpy as np
 
 def _get_with_default(obj, key, default=None):
     return obj[key] if key in obj else default

--- a/python/bifrost/blocks/guppi_raw.py
+++ b/python/bifrost/blocks/guppi_raw.py
@@ -30,6 +30,9 @@ from __future__ import absolute_import
 from bifrost.pipeline import SourceBlock
 import bifrost.guppi_raw as guppi_raw
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _get_with_default(obj, key, default=None):
     return obj[key] if key in obj else default
 

--- a/python/bifrost/blocks/print_header.py
+++ b/python/bifrost/blocks/print_header.py
@@ -31,6 +31,9 @@ from bifrost.pipeline import SinkBlock
 
 from threading import Lock
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class PrintHeaderBlock(SinkBlock):
     lock = Lock()
     def __init__(self, iring, *args, **kwargs):

--- a/python/bifrost/blocks/psrdada.py
+++ b/python/bifrost/blocks/psrdada.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,14 +27,11 @@
 
 from __future__ import absolute_import
 
-from bifrost.pipeline import SourceBlock, SinkBlock
+from bifrost.pipeline import SourceBlock
 from bifrost.Space import Space
 from bifrost.psrdada import Hdu
 from bifrost.libbifrost import _bf, _check
 import bifrost.ndarray
-
-from copy import deepcopy
-import os
 
 # TODO: Move to memory.py?
 def _get_space(arr):

--- a/python/bifrost/blocks/psrdada.py
+++ b/python/bifrost/blocks/psrdada.py
@@ -33,6 +33,9 @@ from bifrost.psrdada import Hdu
 from bifrost.libbifrost import _bf, _check
 import bifrost.ndarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # TODO: Move to memory.py?
 def _get_space(arr):
     if isinstance(arr, bifrost.ndarray):

--- a/python/bifrost/blocks/quantize.py
+++ b/python/bifrost/blocks/quantize.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 from __future__ import absolute_import
 
 import bifrost as bf
-import bifrost.quantize
 from bifrost.pipeline import TransformBlock
 from bifrost.DataType import DataType
 

--- a/python/bifrost/blocks/quantize.py
+++ b/python/bifrost/blocks/quantize.py
@@ -33,6 +33,9 @@ from bifrost.DataType import DataType
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class QuantizeBlock(TransformBlock):
     def __init__(self, iring, dtype, scale=1.,
                  *args, **kwargs):

--- a/python/bifrost/blocks/reduce.py
+++ b/python/bifrost/blocks/reduce.py
@@ -35,6 +35,9 @@ import bifrost as bf
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class ReduceBlock(TransformBlock):
     def __init__(self, iring, axis, factor=None, op='sum', *args, **kwargs):
         super(ReduceBlock, self).__init__(iring, *args, **kwargs)

--- a/python/bifrost/blocks/reverse.py
+++ b/python/bifrost/blocks/reverse.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@ if sys.version_info < (3,):
     
 import bifrost as bf
 from bifrost.pipeline import TransformBlock
-from bifrost.DataType import DataType
 
 from copy import deepcopy
 

--- a/python/bifrost/blocks/reverse.py
+++ b/python/bifrost/blocks/reverse.py
@@ -36,6 +36,9 @@ from bifrost.pipeline import TransformBlock
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class ReverseBlock(TransformBlock):
     def __init__(self, iring, axes, *args, **kwargs):
         super(ReverseBlock, self).__init__(iring, *args, **kwargs)

--- a/python/bifrost/blocks/scrunch.py
+++ b/python/bifrost/blocks/scrunch.py
@@ -34,6 +34,9 @@ from bifrost.pipeline import TransformBlock
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class ScrunchBlock(TransformBlock):
     def __init__(self, iring, factor, *args, **kwargs):
         super(ScrunchBlock, self).__init__(iring, *args, **kwargs)

--- a/python/bifrost/blocks/serialize.py
+++ b/python/bifrost/blocks/serialize.py
@@ -41,6 +41,9 @@ except ImportError:
 import glob
 from functools import reduce
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _parse_bifrost_filename(fname):
     inds = fname[fname.find('.bf.') + 4:].split('.')[:-1]
     inds = [int(i) for i in inds]
@@ -275,4 +278,3 @@ def serialize(iring, path=None, max_file_size=None, *args, **kwargs):
         SerializeBlock: A new block instance.
     """
     return SerializeBlock(iring, path, max_file_size, *args, **kwargs)
-

--- a/python/bifrost/blocks/sigproc.py
+++ b/python/bifrost/blocks/sigproc.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,7 +37,6 @@ from bifrost.DataType import DataType
 from bifrost.units import convert_units
 from numpy import transpose
 
-from copy import deepcopy
 import os
 
 def _get_with_default(obj, key, default=None):

--- a/python/bifrost/blocks/sigproc.py
+++ b/python/bifrost/blocks/sigproc.py
@@ -39,6 +39,9 @@ from numpy import transpose
 
 import os
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _get_with_default(obj, key, default=None):
     return obj[key] if key in obj else default
 

--- a/python/bifrost/blocks/transpose.py
+++ b/python/bifrost/blocks/transpose.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@ from __future__ import absolute_import
 
 from bifrost.pipeline import TransformBlock
 import bifrost as bf
-import bifrost.transpose
 
 from copy import deepcopy
 import numpy as np

--- a/python/bifrost/blocks/transpose.py
+++ b/python/bifrost/blocks/transpose.py
@@ -33,6 +33,9 @@ import bifrost as bf
 from copy import deepcopy
 import numpy as np
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class TransposeBlock(TransformBlock):
     def __init__(self, iring, axes, *args, **kwargs):
         super(TransposeBlock, self).__init__(iring, *args, **kwargs)

--- a/python/bifrost/blocks/unpack.py
+++ b/python/bifrost/blocks/unpack.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 from __future__ import absolute_import
 
 import bifrost as bf
-import bifrost.unpack
 from bifrost.pipeline import TransformBlock
 from bifrost.DataType import DataType
 

--- a/python/bifrost/blocks/unpack.py
+++ b/python/bifrost/blocks/unpack.py
@@ -33,6 +33,9 @@ from bifrost.DataType import DataType
 
 from copy import deepcopy
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class UnpackBlock(TransformBlock):
     def __init__(self, iring, dtype, align_msb=False,
                  *args, **kwargs):

--- a/python/bifrost/blocks/wav.py
+++ b/python/bifrost/blocks/wav.py
@@ -38,6 +38,9 @@ from bifrost.units import convert_units
 import struct
 import os
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def wav_read_chunk_desc(f):
     id_, size, fmt = struct.unpack('<4sI4s', f.read(12))
     try:

--- a/python/bifrost/core.py
+++ b/python/bifrost/core.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 
 from bifrost.libbifrost import _bf
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def status_string(status):
     return _bf.bfGetStatusString(status)
 def debug_enabled():

--- a/python/bifrost/device.py
+++ b/python/bifrost/device.py
@@ -30,6 +30,9 @@ from __future__ import absolute_import
 
 from bifrost.libbifrost import _bf, _check, _get
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def set_device(device):
     if isinstance(device, int):
         _check(_bf.bfDeviceSet(device))

--- a/python/bifrost/dtype.py
+++ b/python/bifrost/dtype.py
@@ -47,6 +47,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf
 import numpy as np
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def split_name_nbit(dtype_str):
     """Splits a dtype string into (name, nbit)"""
     for i, char in enumerate(dtype_str):

--- a/python/bifrost/fdmt.py
+++ b/python/bifrost/fdmt.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,9 +30,6 @@ from __future__ import absolute_import
 
 from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space
 from bifrost.ndarray import asarray
-
-import ctypes
-import numpy as np
 
 class Fdmt(BifrostObject):
     def __init__(self):

--- a/python/bifrost/fdmt.py
+++ b/python/bifrost/fdmt.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Fdmt(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfFdmtCreate, _bf.bfFdmtDestroy)

--- a/python/bifrost/fft.py
+++ b/python/bifrost/fft.py
@@ -32,6 +32,9 @@ from bifrost.libbifrost import _bf, _check, _get, BifrostObject
 from bifrost.ndarray import asarray
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Fft(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfFftCreate, _bf.bfFftDestroy)

--- a/python/bifrost/fft.py
+++ b/python/bifrost/fft.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space
+from bifrost.libbifrost import _bf, _check, _get, BifrostObject
 from bifrost.ndarray import asarray
 import ctypes
 

--- a/python/bifrost/fir.py
+++ b/python/bifrost/fir.py
@@ -1,6 +1,6 @@
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,11 +29,8 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space
-from bifrost.ndarray import asarray, zeros
-
-import ctypes
-import numpy as np
+from bifrost.libbifrost import _bf, _check, BifrostObject, _string2space
+from bifrost.ndarray import asarray
 
 class Fir(BifrostObject):
     def __init__(self):

--- a/python/bifrost/fir.py
+++ b/python/bifrost/fir.py
@@ -32,6 +32,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check, BifrostObject, _string2space
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Fir(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfFirCreate, _bf.bfFirDestroy)

--- a/python/bifrost/guppi_raw.py
+++ b/python/bifrost/guppi_raw.py
@@ -57,6 +57,9 @@ Binary data:
 # Python2 compatibility
 from __future__ import division
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def read_header(f):
     RECORD_LEN = 80
     DIRECTIO_ALIGN_NBYTE = 512

--- a/python/bifrost/guppi_raw.py
+++ b/python/bifrost/guppi_raw.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -57,8 +57,6 @@ Binary data:
 # Python2 compatibility
 from __future__ import division
 
-import numpy as np
-
 def read_header(f):
     RECORD_LEN = 80
     DIRECTIO_ALIGN_NBYTE = 512
@@ -101,12 +99,3 @@ def read_header(f):
         hdr['NTIME'] = hdr['BLOCSIZE'] * 8 // (hdr['OBSNCHAN'] * hdr['NPOL'] *
                                               2 * hdr['NBITS'])
     return hdr
-
-# def read_data(f, hdr):
-#    assert(hdr['NBITS'] == 8)
-#    count = hdr['BLOCSIZE']
-#    shape = (hdr['OBSNCHAN'], hdr['NTIME'], hdr['NPOL'])
-#    data = np.fromfile(f, dtype=np.int8, count=count)
-#    data = data.astype(np.float32).view(np.complex64)
-#    data = data.reshape(shape)
-#    return data

--- a/python/bifrost/header_standard.py
+++ b/python/bifrost/header_standard.py
@@ -43,6 +43,9 @@ Optional parameters (which some blocks require):
 
 """
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # Define a header which we can check passed
 # dictionaries with
 # Format:

--- a/python/bifrost/libbifrost.py
+++ b/python/bifrost/libbifrost.py
@@ -41,6 +41,9 @@ import ctypes
 import bifrost.libbifrost_generated as _bf
 bf = _bf # Public access to library
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # Internal helpers below
 
 class BifrostObject(object):

--- a/python/bifrost/libbifrost.py
+++ b/python/bifrost/libbifrost.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 # Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -61,7 +61,6 @@ class BifrostObject(object):
         self._destroy()
 
 def _array(size_or_vals, dtype=None):
-    import ctypes
     if size_or_vals is None:
         return None
     try:
@@ -169,4 +168,3 @@ SPACE2STRING = {_bf.BF_SPACE_AUTO:         'auto',
                 _bf.BF_SPACE_CUDA_MANAGED: 'cuda_managed'}
 def _space2string(i):
     return SPACE2STRING[i]
-

--- a/python/bifrost/linalg.py
+++ b/python/bifrost/linalg.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check, BifrostObject
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class LinAlg(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfLinAlgCreate, _bf.bfLinAlgDestroy)

--- a/python/bifrost/linalg.py
+++ b/python/bifrost/linalg.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,8 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject
-import ctypes
+from bifrost.libbifrost import _bf, _check, BifrostObject
 from bifrost.ndarray import asarray
 
 class LinAlg(BifrostObject):

--- a/python/bifrost/map.py
+++ b/python/bifrost/map.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@ import sys
 if sys.version_info > (3,):
     long = int
 
-from bifrost.libbifrost import _bf, _check, _get, _array
+from bifrost.libbifrost import _bf, _check, _array
 from bifrost.ndarray import asarray
 import numpy as np
 import ctypes

--- a/python/bifrost/map.py
+++ b/python/bifrost/map.py
@@ -36,6 +36,9 @@ from bifrost.ndarray import asarray
 import numpy as np
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _is_literal(x):
     return isinstance(x, (int, long, float, complex))
 

--- a/python/bifrost/memory.py
+++ b/python/bifrost/memory.py
@@ -32,6 +32,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check, _get, _string2space
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def space_accessible(space, from_spaces):
     if from_spaces == 'any': # TODO: This is a little bit hacky
         return True

--- a/python/bifrost/ndarray.py
+++ b/python/bifrost/ndarray.py
@@ -51,6 +51,9 @@ from bifrost.DataType import DataType
 from bifrost.Space import Space
 import sys
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # TODO: The stuff here makes array.py redundant (and outdated)
 
 # TODO: ndarray.flags['WRITEABLE'] does not get preserved

--- a/python/bifrost/pipeline.py
+++ b/python/bifrost/pipeline.py
@@ -52,6 +52,9 @@ from bifrost.temp_storage import TempStorage
 from bifrost.proclog import ProcLog
 from bifrost.ndarray import memset_array # TODO: This feels a bit hacky
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # Note: This must be called before any devices are initialized. It's also
 #          almost always desirable when running pipelines, so we do it here at
 #          module import time to make things easy.

--- a/python/bifrost/pipeline.py
+++ b/python/bifrost/pipeline.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -112,8 +112,9 @@ class BlockScope(object):
     def __enter__(self):
         thread_local.blockscope_stack.append(self)
     def __exit__(self, type, value, tb):
-        if __debug__: assert(thread_local.blockscope_stack.pop() is self)
-        else: thread_local.blockscope_stack.pop()
+        popped = thread_local.blockscope_stack.pop()
+        if __debug__:
+            assert(popped is self)
     def __getattr__(self, name):
         # Use child's value if set, othersize defer to parent
         if '_'+name not in self.__dict__:
@@ -282,8 +283,9 @@ class Pipeline(BlockScope):
         thread_local.pipeline_stack.append(self)
         return self
     def __exit__(self, type, value, tb):
-        if __debug__: assert(thread_local.pipeline_stack.pop() is self)
-        else: thread_local.pipeline_stack.pop()
+        popped = thread_local.pipeline_stack.pop()
+        if __debug__:
+            assert(popped is self)
 
 # Create the default pipeline object
 thread_local.pipeline_stack.append(Pipeline())

--- a/python/bifrost/portaudio.py
+++ b/python/bifrost/portaudio.py
@@ -38,6 +38,9 @@ import atexit
 from threading import Lock
 import os
 
+from bifrost import telemetry
+telemetry.track_module()
+
 # Note: portaudio is MIT licensed
 _lib = ctypes.cdll.LoadLibrary('libportaudio.so')
 

--- a/python/bifrost/proclog.py
+++ b/python/bifrost/proclog.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,18 +31,10 @@ import sys
 if sys.version_info < (3,):
     range = xrange
     
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject
+from bifrost.libbifrost import _bf, _check, BifrostObject
 
 import os
 import time
-import ctypes
-import numpy as np
-
-try:
-    import simplejson as json
-except ImportError:
-    print("WARNING: Install simplejson for better performance")
-    import json
 
 class ProcLog(BifrostObject):
     def __init__(self, name):

--- a/python/bifrost/proclog.py
+++ b/python/bifrost/proclog.py
@@ -36,6 +36,9 @@ from bifrost.libbifrost import _bf, _check, BifrostObject
 import os
 import time
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class ProcLog(BifrostObject):
     def __init__(self, name):
         try:

--- a/python/bifrost/psrdada.py
+++ b/python/bifrost/psrdada.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,14 +41,10 @@ libtest_la_LDFLAGS = -version-info 0:0:0
 
 from __future__ import absolute_import, print_function
 
-from bifrost.pipeline import SourceBlock, SinkBlock
-from bifrost.DataType import DataType
 import bifrost.libpsrdada_generated as _dada
 import numpy as np
 from bifrost.ndarray import _address_as_buffer
 
-from copy import deepcopy
-import os
 import ctypes
 
 def get_pointer_value(ptr):

--- a/python/bifrost/psrdada.py
+++ b/python/bifrost/psrdada.py
@@ -47,6 +47,9 @@ from bifrost.ndarray import _address_as_buffer
 
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def get_pointer_value(ptr):
     return ctypes.c_void_p.from_buffer(ptr).value
 

--- a/python/bifrost/quantize.py
+++ b/python/bifrost/quantize.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,8 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get
-import ctypes
+from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
 def quantize(src, dst, scale=1.):

--- a/python/bifrost/quantize.py
+++ b/python/bifrost/quantize.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def quantize(src, dst, scale=1.):
     src_bf = asarray(src).as_BFarray()
     dst_bf = asarray(dst).as_BFarray()

--- a/python/bifrost/reduce.py
+++ b/python/bifrost/reduce.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 REDUCE_MAP = {
     'sum':       _bf.BF_REDUCE_SUM,
     'mean':      _bf.BF_REDUCE_MEAN,

--- a/python/bifrost/ring.py
+++ b/python/bifrost/ring.py
@@ -39,6 +39,9 @@ import string
 import numpy as np
 from uuid import uuid4
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _slugify(name):
     valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
     valid_chars = frozenset(valid_chars)

--- a/python/bifrost/ring2.py
+++ b/python/bifrost/ring2.py
@@ -46,6 +46,9 @@ except ImportError:
     print("WARNING: Install simplejson for better performance")
     import json
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _slugify(name):
     valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
     valid_chars = frozenset(valid_chars)

--- a/python/bifrost/ring2.py
+++ b/python/bifrost/ring2.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 
 from __future__ import print_function, absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space, _space2string
+from bifrost.libbifrost import _bf, _check, _get, BifrostObject, _string2space
 from bifrost.DataType import DataType
 from bifrost.ndarray import ndarray, _address_as_buffer
 from copy import copy, deepcopy

--- a/python/bifrost/romein.py
+++ b/python/bifrost/romein.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check, BifrostObject
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class Romein(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfRomeinCreate, _bf.bfRomeinDestroy)

--- a/python/bifrost/romein.py
+++ b/python/bifrost/romein.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2018-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2018-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,8 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject
-import ctypes
+from bifrost.libbifrost import _bf, _check, BifrostObject
 from bifrost.ndarray import asarray
 
 class Romein(BifrostObject):
@@ -53,4 +52,3 @@ class Romein(BifrostObject):
                                     asarray(idata).as_BFarray(),
                                     asarray(odata).as_BFarray()) )
         return odata
-

--- a/python/bifrost/sigproc.py
+++ b/python/bifrost/sigproc.py
@@ -59,6 +59,9 @@ import numpy as np
 from collections import defaultdict
 import os
 
+from bifrost import telemetry
+telemetry.track_module()
+
 #header parameter names which precede strings
 _STRING_VALUES = ['source_name',
                   'rawdatafile']

--- a/python/bifrost/sigproc2.py
+++ b/python/bifrost/sigproc2.py
@@ -59,6 +59,9 @@ import struct
 import numpy as np
 from collections import defaultdict
 
+from bifrost import telemetry
+telemetry.track_module()
+
 _string_values = ['source_name',
                   'rawdatafile']
 _double_values = ['az_start',

--- a/python/bifrost/telemetry.py
+++ b/python/bifrost/telemetry.py
@@ -101,7 +101,7 @@ class _TelemetryClient(object):
         Add an entry to the telemetry cache with optional timing information.
         """
         
-        if name[:3] != 'bifrost' or not self.active:
+        if name[:7] != 'bifrost' or not self.active:
             return False
             
         with self._lock:

--- a/python/bifrost/telemetry.py
+++ b/python/bifrost/telemetry.py
@@ -45,7 +45,7 @@ except ImportError:
 from threading import RLock
 from functools import wraps
 
-import bifrost
+import bifrost.version
 
 # Create the cache directory
 if not os.path.exists(os.path.join(os.path.expanduser('~'), '.bifrost')):
@@ -78,7 +78,7 @@ class _TelemetryClient(object):
     """
     _lock = RLock()
     
-    def __init__(self, key, version=bifrost.__version__):
+    def __init__(self, key, version=bifrost.version.__version__):
         # Setup
         self.key = key
         self.version = version

--- a/python/bifrost/telemetry.py
+++ b/python/bifrost/telemetry.py
@@ -1,0 +1,371 @@
+
+# Copyright (c) 2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2021, The University of New Mexico. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of The Bifrost Authors nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Python2 compatibility
+from __future__ import print_function, division, absolute_import
+
+import os
+import time
+import uuid
+import atexit
+import socket
+import inspect
+import warnings
+try:
+    from urllib2 import urlopen
+    from urllib import urlencode
+except ImportError:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+from threading import RLock
+from functools import wraps
+
+import bifrost
+
+# Create the cache directory
+if not os.path.exists(os.path.join(os.path.expanduser('~'), '.bifrost')):
+    os.mkdir(os.path.join(os.path.expanduser('~'), '.bifrost'))
+_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.bifrost', 'telemetry_cache')
+if not os.path.exists(_CACHE_DIR):
+    os.mkdir(_CACHE_DIR)
+
+# Load the install ID key, creating it if it doesn't exist
+_INSTALL_KEY = os.path.join(_CACHE_DIR, 'install.key')
+if not os.path.exists(_INSTALL_KEY):
+    with open(_INSTALL_KEY, 'w') as fh:
+        fh.write(str(uuid.uuid4()))
+
+with open(_INSTALL_KEY, 'r') as fh:
+    _INSTALL_KEY = fh.read().rstrip()
+
+# Reporting control
+TELEMETRY_MAX_ENTRIES = 100
+TELEMETRY_TIMEOUT     = 120   # s
+TELEMETRY_ACTIVE      = True
+_ACTIVE_KEY = os.path.join(_CACHE_DIR, 'do_not_report')
+if os.path.exists(_ACTIVE_KEY):
+    TELEMETRY_ACTIVE = False
+
+
+class _TelemetryClient(object):
+    """
+    Bifrost telemetry client to help understand usage of the Bifrost Python interface.
+    """
+    _lock = RLock()
+    
+    def __init__(self, key, version=bifrost.__version__):
+        # Setup
+        self.key = key
+        self.version = version
+        
+        # Session reference
+        self._session_start = time.time()
+        
+        # Telemetry cache
+        self._cache = {}
+        self._cache_count = 0
+        
+        # Reporting lockout
+        self.active = TELEMETRY_ACTIVE
+        
+        # Register the "send" method to be called by atexit... at exit
+        atexit.register(self.send, True)
+        
+    def track(self, name, timing=0.0):
+        """
+        Add an entry to the telemetry cache with optional timing information.
+        """
+        
+        if name[:3] != 'bifrost' or not self.active:
+            return False
+            
+        with self._lock:
+            try:
+                self._cache[name][0] += 1
+                self._cache[name][1] += (1 if timing > 0 else 0)
+                self._cache[name][2] += timing
+            except KeyError:
+                self._cache[name] = [1, 0, timing]
+                self._cache[name][1] += (1 if timing > 0 else 0)
+                self._cache_count += 1
+                
+            if self._cache_count >= TELEMETRY_MAX_ENTRIES:
+                self.send()
+                
+        return True
+                
+    def send(self, final=False):
+        """
+        Send the current cache of telemetry data back to the maintainers for 
+        analysis.
+        """
+        
+        success = False
+        with self._lock:
+            if self.active and self._cache_count > 0:
+                try:
+                    tNow = time.time()
+                    payload = ';'.join(["%s;%i;%i;%.6f" % (name,
+                                                           self._cache[name][0],
+                                                           self._cache[name][1],
+                                                           self._cache[name][2]) for name in self._cache])
+                    payload = urlencode({'timestamp'   : int(tNow),
+                                         'key'         : self.key, 
+                                         'version'     : self.version,
+                                         'session_time': "%.6f" % ((tNow-self._session_start) if final else 0.0,),
+                                         'payload'     : payload})
+                    try:
+                        payload = payload.encode()
+                    except AttributeError:
+                        pass
+                    uh = urlopen('https://fornax.phys.unm.edu/telemetry/bifrost.php', payload, 
+                                 timeout=TELEMETRY_TIMEOUT)
+                    status = uh.read()
+                    if status == '':
+                        self.clear()
+                        success = True
+                except Exception as e:
+                    warnings.warn("Failed to send telemetry data: %s" % str(e))
+            else:
+                self.clear()
+                
+        return success
+                
+    def clear(self):
+        """
+        Clear the current telemetry cache.
+        """
+        
+        with self._lock:
+            self._cache.clear()
+            self._cache_count = 0
+            
+    @property
+    def is_active(self):
+        """
+        Whether or not the cache is active and sending data back.
+        """
+        
+        return self.active
+        
+    def enable(self):
+        """
+        Enable saving data to the telemetry cache.
+        """
+        
+        TELEMETRY_ACTIVE = True
+        try:
+            os.unlink(_ACTIVE_KEY)
+        except OSError:
+            pass
+        self.active = TELEMETRY_ACTIVE
+        
+    def disable(self):
+        """
+        Disable saving data to the telemetry cache in a persistent way.
+        """
+        
+        TELEMETRY_ACTIVE = False
+        try:
+            with open(_ACTIVE_KEY, 'w') as fh:
+                fh.write('True')
+        except OSError:
+            pass
+        self.active = TELEMETRY_ACTIVE
+
+
+# Create an instance of the telemetry client to use.
+_telemetry_client = _TelemetryClient(_INSTALL_KEY)
+
+
+# Telemetry control
+def is_active():
+    """
+    Return a boolean of whether or not the Bifrost telemetry client is active.
+    """
+    
+    global _telemetry_client
+    return _telemetry_client.is_active
+
+
+def enable():
+    """
+    Enable logging of usage data via the Bifrost telemetry client.
+    """
+    
+    global _telemetry_client
+    _telemetry_client.enable()
+
+
+def disable():
+    """
+    Disable logging of usage data via the Bifrost telemetry client.
+    
+    .. note::
+        This function disables in a global way that persists across
+        invocations.
+    """
+    
+    global _telemetry_client
+    _telemetry_client.disable()
+
+
+def ignore():
+    """
+    Temporarily disable logging of usage data via the Bifrost telemetry client.
+    
+    .. note::
+        This function only stops logging after it is called and until enable()
+        is called again.  For a persistent call use disable().
+    """
+    
+    global _telemetry_client
+    _telemetry_client.ignore()
+
+
+def track_script():
+    """
+    Record the use of a Bifrost script.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    name = os.path.basename(caller.f_globals['__file__'])
+    _telemetry_client.track('bifrost.tools.'+name)
+
+
+def track_module():
+    """
+    Record the import of an Bifrost module.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    _telemetry_client.track(caller.f_globals['__name__'])
+
+
+def track_function(user_function):
+    """
+    Record the use of a function in Bifrost without execution time information.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    mod = caller.f_globals['__name__']
+    fnc = user_function.__name__
+    name = mod+'.'+fnc+'()'
+    
+    @wraps(user_function)
+    def wrapper(*args, **kwds):
+        global _telemetry_client
+        result =  user_function(*args, **kwds)
+        
+        _telemetry_client.track(name)
+        return result
+        
+    return wrapper
+
+
+def track_function_timed(user_function):
+    """
+    Record the use of a function in Bifrost with execution time information.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    mod = caller.f_globals['__name__']
+    fnc = user_function.__name__
+    name = mod+'.'+fnc+'()'
+    
+    @wraps(user_function)
+    def wrapper(*args, **kwds):
+        global _telemetry_client
+        t0 = time.time()
+        result = user_function(*args, **kwds)
+        t1 = time.time()
+        
+        _telemetry_client.track(name, t1-t0)
+        return result
+        
+    return wrapper
+
+
+def track_method(user_method):
+    """
+    Record the use of a method in Bifrost with execution time information.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    mod = caller.f_globals['__name__']
+    cls = None
+    fnc = user_method.__name__
+    name = mod+'.'+'%s'+'.'+fnc+'()'
+    
+    @wraps(user_method)
+    def wrapper(*args, **kwds):
+        global _telemetry_client
+        result =  user_method(*args, **kwds)
+        
+        cls = type(args[0]).__name__
+        _telemetry_client.track(name % cls)
+        return result
+        
+    return wrapper
+
+
+def track_method_timed(user_method):
+    """
+    Record the use of a method in Bifrost with execution time information.
+    """
+    
+    global _telemetry_client
+    
+    caller = inspect.currentframe().f_back
+    mod = caller.f_globals['__name__']
+    cls = None
+    fnc = user_method.__name__
+    name = mod+'.'+'%s'+'.'+fnc+'()'
+    
+    @wraps(user_method)
+    def wrapper(*args, **kwds):
+        global _telemetry_client
+        t0 = time.time()
+        result =  user_method(*args, **kwds)
+        t1 = time.time()
+        
+        cls = type(args[0]).__name__
+        _telemetry_client.track(name % cls, t1-t0)
+        return result
+        
+    return wrapper

--- a/python/bifrost/telemetry.py
+++ b/python/bifrost/telemetry.py
@@ -235,19 +235,6 @@ def disable():
     _telemetry_client.disable()
 
 
-def ignore():
-    """
-    Temporarily disable logging of usage data via the Bifrost telemetry client.
-    
-    .. note::
-        This function only stops logging after it is called and until enable()
-        is called again.  For a persistent call use disable().
-    """
-    
-    global _telemetry_client
-    _telemetry_client.ignore()
-
-
 def track_script():
     """
     Record the use of a Bifrost script.

--- a/python/bifrost/temp_storage.py
+++ b/python/bifrost/temp_storage.py
@@ -29,6 +29,9 @@ import bifrost as bf
 
 import threading
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class TempStorage(object):
     def __init__(self, space):
         self.space = space

--- a/python/bifrost/transpose.py
+++ b/python/bifrost/transpose.py
@@ -33,6 +33,9 @@ from bifrost.ndarray import asarray
 
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def transpose(dst, src, axes=None):
     if axes is None:
         axes = reversed(range(len(dst.shape)))

--- a/python/bifrost/transpose.py
+++ b/python/bifrost/transpose.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get, _string2space
+from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
 import ctypes

--- a/python/bifrost/udp_capture.py
+++ b/python/bifrost/udp_capture.py
@@ -29,6 +29,9 @@
 
 from bifrost.libbifrost import _bf, _check, BifrostObject
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class UDPCapture(BifrostObject):
     def __init__(self, fmt, sock, ring, nsrc, src0, max_payload_size,
                  buffer_ntime, slot_ntime, sequence_callback, core=None):

--- a/python/bifrost/udp_capture.py
+++ b/python/bifrost/udp_capture.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 # **TODO: Write tests for this class
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject
+from bifrost.libbifrost import _bf, _check, BifrostObject
 
 class UDPCapture(BifrostObject):
     def __init__(self, fmt, sock, ring, nsrc, src0, max_payload_size,

--- a/python/bifrost/udp_socket.py
+++ b/python/bifrost/udp_socket.py
@@ -32,6 +32,9 @@ from __future__ import absolute_import
 
 from bifrost.libbifrost import _bf, _check, _get, BifrostObject
 
+from bifrost import telemetry
+telemetry.track_module()
+
 class UDPSocket(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _bf.bfUdpSocketCreate, _bf.bfUdpSocketDestroy)

--- a/python/bifrost/udp_transmit.py
+++ b/python/bifrost/udp_transmit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 
 # **TODO: Write tests for this class
 
-from bifrost.libbifrost import _bf, _check, _get, BifrostObject
+from bifrost.libbifrost import _bf, _check, BifrostObject
 
 import ctypes
 

--- a/python/bifrost/udp_transmit.py
+++ b/python/bifrost/udp_transmit.py
@@ -32,6 +32,9 @@ from bifrost.libbifrost import _bf, _check, BifrostObject
 
 import ctypes
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def _packet2pointer(packet):
     buf = ctypes.c_char_p(packet)
     siz = ctypes.c_uint( len(packet) )

--- a/python/bifrost/units.py
+++ b/python/bifrost/units.py
@@ -27,6 +27,9 @@
 
 import pint
 
+from bifrost import telemetry
+telemetry.track_module()
+
 ureg = pint.UnitRegistry()
 
 def convert_units(value, old_units, new_units):

--- a/python/bifrost/unpack.py
+++ b/python/bifrost/unpack.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,8 +28,7 @@
 # Python2 compatibility
 from __future__ import absolute_import
 
-from bifrost.libbifrost import _bf, _check, _get
-import ctypes
+from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
 def unpack(src, dst, align_msb=False):

--- a/python/bifrost/unpack.py
+++ b/python/bifrost/unpack.py
@@ -31,6 +31,9 @@ from __future__ import absolute_import
 from bifrost.libbifrost import _bf, _check
 from bifrost.ndarray import asarray
 
+from bifrost import telemetry
+telemetry.track_module()
+
 def unpack(src, dst, align_msb=False):
     src_bf = asarray(src).as_BFarray()
     dst_bf = asarray(dst).as_BFarray()

--- a/python/bifrost/views/basic_views.py
+++ b/python/bifrost/views/basic_views.py
@@ -32,6 +32,8 @@ from bifrost.DataType import DataType
 from bifrost.units import convert_units
 from numpy import isclose
 
+from bifrost import telemetry
+telemetry.track_module()
 
 def custom(block, hdr_transform):
     """An alias to `bifrost.pipeline.block_view`

--- a/python/bifrost/views/basic_views.py
+++ b/python/bifrost/views/basic_views.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,7 +31,6 @@ from bifrost.pipeline import block_view
 from bifrost.DataType import DataType
 from bifrost.units import convert_units
 from numpy import isclose
-from copy import deepcopy
 
 
 def custom(block, hdr_transform):

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,6 +29,7 @@
 # Python2 compatibility
 from __future__ import print_function
 
+from distutils.command.install import install
 from setuptools import setup, find_packages
 import os
 import sys
@@ -54,10 +55,23 @@ except IOError:
     print("*************************************************************************")
     raise
 
+# Override "install" to show the telemetry warning
+class bifrost_install(install):
+    def run(self):
+        install.run(self)
+        print("*************************************************************************")
+        print("By default Bifrost installs with basic Python telemetry enabled in order ")
+        print("order to help inform how the software is used and to help inform future  ")
+        print("development.  You can opt out of telemetry collection using:             ")
+        print(">>> from bifrost import telemetry                                        ")
+        print(">>> telemetry.disable()                                                  ")
+        print("*************************************************************************")
+
 # Build up a list of scripts to install
 scripts = glob.glob(os.path.join('..', 'tools', '*.py'))
 
-setup(name='bifrost',
+setup(cmdclass={'install': bifrost_install,},
+      name='bifrost',
       version=__version__,
       description='Pipeline processing framework',
       author='Ben Barsdell',

--- a/src/proclog.cpp
+++ b/src/proclog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,14 +119,14 @@ class ProcLogMgr {
 					try {
 						remove_all(std::string(base_logdir) + "/" +
 							   std::to_string(pid));
-					} catch( std::exception ) {}
+					} catch( std::exception& ) {}
 				}
 			}
 			closedir(dp);
 		}
 		// Remove the base_logdir if it's empty
 		try { remove_dir(base_logdir); }
-		catch( std::exception ) {}
+		catch( std::exception& ) {}
 	}
 	ProcLogMgr()
 		: _logdir(std::string(base_logdir) + "/" + std::to_string(getpid())) {
@@ -138,7 +138,7 @@ class ProcLogMgr {
 		try {
 			remove_all(_logdir);
 			this->try_base_logdir_cleanup();
-		} catch( std::exception ) {}
+		} catch( std::exception& ) {}
 	}
 	FILE* open_file(std::string filename) {
 		// Note: Individual log dirs and files are only created if they are

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2016-2021, The Bifrost Authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +73,7 @@ BFstatus bfUdpSocketGetTimeout(BFudpsocket obj, double* secs) {
 	try {
 		*secs = obj->get_timeout();
 	}
-	catch( Socket::Error ) {
+	catch( Socket::Error& ) {
 		*secs = 0;
 		return BF_STATUS_INVALID_STATE;
 	}
@@ -92,7 +92,7 @@ BFstatus bfUdpSocketGetMTU(BFudpsocket obj, int* mtu) {
 	try {
 		*mtu = obj->get_mtu();
 	}
-	catch( Socket::Error ) {
+	catch( Socket::Error& ) {
 		*mtu = 0;
 		return BF_STATUS_INVALID_STATE;
 	}

--- a/test/download_test_data.sh
+++ b/test/download_test_data.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-curl -L -O http://mcranmer.com/data/bf_test_files.tar.gz
-if [[ "$?" != "0" ]]; then
-	curl -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
-fi
+curl -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
 tar xzf bf_test_files.tar.gz
 mv for_test_suite data
 rm bf_test_files.tar.gz

--- a/test/download_test_data.sh
+++ b/test/download_test_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 curl -L -O http://mcranmer.com/data/bf_test_files.tar.gz
 if [[ "$?" != "0" ]]; then
-	curl -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
+	curl --insecure -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
 fi
 tar xzf bf_test_files.tar.gz
 mv for_test_suite data

--- a/test/download_test_data.sh
+++ b/test/download_test_data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 curl -L -O http://mcranmer.com/data/bf_test_files.tar.gz
 if [[ "$?" != "0" ]]; then
-	curl --insecure -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
+	curl -L -O https://fornax.phys.unm.edu/lwa/data/bf_test_files.tar.gz
 fi
 tar xzf bf_test_files.tar.gz
 mv for_test_suite data

--- a/test/jenkins.sh
+++ b/test/jenkins.sh
@@ -2,6 +2,7 @@
 # This file runs CPU and GPU tests for jenkins
 ./download_test_data.sh
 export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+python -c "from bifrost import telemetry; telemetry.disable()"
 coverage run --source=bifrost.ring,bifrost,bifrost.pipeline -m unittest \
   test_block \
   test_sigproc \

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -2,6 +2,7 @@
 # This file runs CPU-safe tests for travis-ci
 ./download_test_data.sh
 export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+python -c "from bifrost import telemetry; telemetry.disable()"
 coverage run --source=bifrost.ring,bifrost,bifrost.pipeline -m unittest \
   test_block \
   test_sigproc \

--- a/tools/bifrost_telemetry.py
+++ b/tools/bifrost_telemetry.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2021, The University of New Mexico. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of The Bifrost Authors nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Python2 compatibility
+from __future__ import print_function, division, absolute_import
+    
+import os
+import sys
+import argparse
+
+from bifrost import telemetry
+telemetry.track_script()
+
+
+def main(args):
+    # Toggle
+    if args.enable:
+        telemetry.enable()
+    elif args.disable:
+        telemetry.disable()
+        
+    # Report
+    ## Status
+    print("Bifrost Telemetry is %s" % ('active' if telemetry.is_active() else 'in-active'))
+    
+    ## Key
+    if args.key:
+        print("  Identification key: %s" % telemetry._INSTALL_KEY)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+            description='update the Bifrost telemetry setting', 
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+    tgroup = parser.add_mutually_exclusive_group(required=False)
+    tgroup.add_argument('-e', '--enable', action='store_true', 
+                        help='enable telemetry for Bifrost')
+    tgroup.add_argument('-d', '--disable', action='store_true', 
+                        help='disable telemetry for Bifrost')
+    parser.add_argument('-k', '--key', action='store_true',
+                        help='show install identification key')
+    args = parser.parse_args()
+    main(args)

--- a/tools/getirq.py
+++ b/tools/getirq.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,8 +29,6 @@
 # Python2 compatibility
 from __future__ import print_function
 
-import os
-import sys
 import argparse
 
 

--- a/tools/getirq.py
+++ b/tools/getirq.py
@@ -31,6 +31,9 @@ from __future__ import print_function
 
 import argparse
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 def main(args):
     fh = open('/proc/interrupts', 'r')

--- a/tools/getsiblings.py
+++ b/tools/getsiblings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,8 +30,6 @@
 # Python2 compatibility
 from __future__ import print_function
 
-import os
-import sys
 import glob
 import argparse
 

--- a/tools/getsiblings.py
+++ b/tools/getsiblings.py
@@ -33,6 +33,9 @@ from __future__ import print_function
 import glob
 import argparse
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 def read_siblings():
     cpus = glob.glob('/sys/devices/system/cpu/cpu*/topology/thread_siblings_list')

--- a/tools/like_bmon.py
+++ b/tools/like_bmon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -294,7 +294,13 @@ def main(args):
             ## For sel to be valid - this takes care of any changes between when 
             ## we get what to select and when we polled the bifrost logs
             sel = min([nPID-1, sel])
-
+            
+            ## Deal with more pipelines than there is screen space by skipping
+            ## over some at the beginning of the list
+            to_skip = 0
+            if sel > size[0] - 13:
+                to_skip = sel - size[0] + 13
+                
             ## Display
             k = 0
             ### General - selected
@@ -313,7 +319,10 @@ def main(args):
             output += '\n'
             k = _add_line(scr, k, 0, output, rev)
             ### Data
-            for o in order:
+            for i,o in enumerate(order):
+                if i < to_skip:
+                    continue
+                    
                 curr = stats[o]
                 if o == order[sel]:
                     act = curr
@@ -335,7 +344,7 @@ def main(args):
                     sty = std
                 k = _add_line(scr, k, 0, output, sty)
 
-                if k > size[0]-9:
+                if k > size[0]-10:
                     break
             while k < size[0]-9:
                 output = ' '

--- a/tools/like_bmon.py
+++ b/tools/like_bmon.py
@@ -40,7 +40,7 @@ import argparse
 import traceback
 from datetime import datetime
 try:
-    import cStringIO as StringIO
+    from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 

--- a/tools/like_bmon.py
+++ b/tools/like_bmon.py
@@ -47,6 +47,9 @@ except ImportError:
 os.environ['VMA_TRACELEVEL'] = '0'
 from bifrost.proclog import load_by_pid
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 BIFROST_STATS_BASE_DIR = '/dev/shm/bifrost/'
 

--- a/tools/like_pmap.py
+++ b/tools/like_pmap.py
@@ -38,6 +38,9 @@ import subprocess
 os.environ['VMA_TRACELEVEL'] = '0'
 from bifrost.proclog import load_by_pid
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 def get_best_size(value):
     """

--- a/tools/like_pmap.py
+++ b/tools/like_pmap.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@ from __future__ import print_function
 
 import os
 import re
-import sys
 import argparse
 import subprocess
 

--- a/tools/like_ps.py
+++ b/tools/like_ps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,9 +31,7 @@
 from __future__ import print_function
 
 import os
-import sys
 import glob
-import time
 import argparse
 import subprocess
 

--- a/tools/like_ps.py
+++ b/tools/like_ps.py
@@ -38,6 +38,9 @@ import subprocess
 os.environ['VMA_TRACELEVEL'] = '0'
 from bifrost.proclog import load_by_pid
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 BIFROST_STATS_BASE_DIR = '/dev/shm/bifrost/'
 

--- a/tools/like_top.py
+++ b/tools/like_top.py
@@ -50,6 +50,9 @@ except ImportError:
 os.environ['VMA_TRACELEVEL'] = '0'
 from bifrost.proclog import load_by_pid
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 BIFROST_STATS_BASE_DIR = '/dev/shm/bifrost/'
 

--- a/tools/like_top.py
+++ b/tools/like_top.py
@@ -419,7 +419,6 @@ def main(args):
         for j in range(x):
             d = scr.inch(i,j)
             c = d&0xFF
-            a = (d>>8)&0xFF
             contents += chr(c)
 
     # Tear down curses

--- a/tools/like_top.py
+++ b/tools/like_top.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -78,7 +78,7 @@ def get_load_average():
         data['lastPID'] = fields[4]
     return data
 
-global _CPU_STATE
+_CPU_STATE
 _CPU_STATE = {}
 def get_processor_usage():
     """
@@ -92,7 +92,9 @@ def get_processor_usage():
     NOTE::  Many of these details could be avoided by using something like the
           Python 'psutil' module.
     """
-
+    
+    global _CPU_STATE
+    
     data = {'avg': {'user':0.0, 'nice':0.0, 'sys':0.0, 'idle':0.0, 'wait':0.0, 'irq':0.0, 'sirq':0.0, 'steal':0.0, 'total':0.0}}
 
     with open('/proc/stat', 'r') as fh:

--- a/tools/pipeline2dot.py
+++ b/tools/pipeline2dot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
-# Copyright (c) 2017-2020, The University of New Mexico. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The University of New Mexico. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@ from __future__ import print_function
 import os
 import sys
 import glob
-import time
 import argparse
 import subprocess
 
@@ -158,36 +157,36 @@ def get_data_flows(blocks):
                 refBlock = block
                 refROuts = routs
 
-                for block in blocks.keys():
-                    rins, routs = [], []
+                for other_block in blocks.keys():
+                    other_rins, other_routs = [], []
                     dtype = None
-                    for log in blocks[block].keys():
+                    for log in blocks[other_block].keys():
                         if log.startswith('sequence'):
                             try:
-                                bits = blocks[block][log]['nbit']
-                                if blocks[block][log]['complex']:
+                                bits = blocks[other_block][log]['nbit']
+                                if blocks[other_block][log]['complex']:
                                     bits *= 2
-                                name = 'cplx' if  blocks[block][log]['complex'] else 'real'
+                                name = 'cplx' if  blocks[other_block][log]['complex'] else 'real'
                                 dtype = '%s%i' % (name, bits)
                             except KeyError:
                                 pass
                         elif log not in ('in', 'out'):
                             continue
 
-                        for key in blocks[block][log]:
+                        for key in blocks[other_block][log]:
                             if key[:4] == 'ring':
-                                value = blocks[block][log][key]
+                                value = blocks[other_block][log][key]
                                 if log == 'in':
-                                    if value not in rins:
-                                        rins.append( value )
+                                    if value not in other_rins:
+                                        other_rins.append( value )
                                 else:
-                                    if value not in routs:
-                                        routs.append( value )
+                                    if value not in other_routs:
+                                        other_routs.append( value )
 
-                    for ring in rins:
+                    for ring in other_rins:
                         if ring in refROuts:
                             #print(refRing, rins, block)
-                            chains.append( {'link':(refBlock,block), 'dtype':dtype} )
+                            chains.append( {'link':(refBlock,other_block), 'dtype':dtype} )
 
     # Find out the associations (based on core binding)
     associations = []
@@ -203,25 +202,25 @@ def get_data_flows(blocks):
         if len(refCores) == 0:
             continue
 
-        for block in blocks:
-            if block == refBlock:
+        for other_block in blocks:
+            if other_block == refBlock:
                 continue
 
-            cores = []
+            other_cores = []
             for i in range(32):
                 try:
-                    cores.append( blocks[block]['bind']['core%i' % i] )
+                    other_cores.append( blocks[other_block]['bind']['core%i' % i] )
                 except KeyError:
                     break
 
-            if len(cores) == 0:
+            if len(other_cores) == 0:
                 continue
 
-            for core in cores:
+            for core in other_cores:
                 if core in refCores:
-                    if (refBlock,block) not in associations:
-                        if (block,refBlock) not in associations:
-                            associations.append( (refBlock, block) )
+                    if (refBlock,other_block) not in associations:
+                        if (other_block,refBlock) not in associations:
+                            associations.append( (refBlock, other_block) )
 
     return sources, sinks, chains, associations
 

--- a/tools/pipeline2dot.py
+++ b/tools/pipeline2dot.py
@@ -38,6 +38,9 @@ import subprocess
 
 from bifrost.proclog import load_by_pid
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 BIFROST_STATS_BASE_DIR = '/dev/shm/bifrost/'
 

--- a/tools/setirq.py
+++ b/tools/setirq.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2017-2020, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2017-2021, The Bifrost Authors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,8 +29,6 @@
 # Python2 compatibility
 from __future__ import print_function
 
-import os
-import sys
 import argparse
 
 

--- a/tools/setirq.py
+++ b/tools/setirq.py
@@ -31,6 +31,9 @@ from __future__ import print_function
 
 import argparse
 
+from bifrost import telemetry
+telemetry.track_script()
+
 
 def compute_mask(cpu):
     """


### PR DESCRIPTION
This PR adds a lightweight telemetry client to Bifrost to help provide insight into the users and usage of the Python portions of the library.  This includes the ability to:

 * track which Bifrost modules are imported,
 * track which scripts in the `tools` directory are used,
 * and record the average pipeline runtime.
 
All of this can be toggled on/off using either functions in the `bifrost.telemetry` module or with the `bifrost_telemetry.py` script in `tools`.