### PR TITLE
Nix build using flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -71,14 +71,13 @@ jobs:
 
       - name: Deploy documentation to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4.2.5
-        # Change github.ref below to master after #162 merged.  Might
-        # only deploy if changes in doc/ folder?  (But some doc pages
-        # generated from code, so maybe should reflect code changes.)
+        # Maybe only deploy if changes in doc/ folder?  (But some doc
+        # pages generated from code, so should reflect code changes?)
         if: |
           matrix.os == 'ubuntu-latest'
           && matrix.nixpkgs == 'pinned'
           && github.event_name == 'push'
-          && github.ref == 'refs/heads/nix-flake'
+          && github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: result-doc/share/doc/bifrost/html

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,81 @@
+---
+name: "Nix Build"
+"on": [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        nixpkgs:
+          - pinned
+          - release-21.11
+          - release-21.05
+          - nixpkgs-unstable
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Link to bifrost binary cache on cachix.org
+        uses: cachix/cachix-action@v10
+        with:
+          name: bifrost
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Lock the version of nixpkgs specified by the matrix
+        run: |
+          if "${{ matrix.nixpkgs }}" != "pinned"; then
+            nix flake lock --override-input nixpkgs \
+              "nixpkgs/${{ matrix.nixpkgs }}"
+          fi
+          nix flake metadata
+
+      - name: Check for well-formed flake
+        run: |
+          nix flake check
+
+      - name: Build for default python3
+        run: |
+          nix build --print-build-logs .#bifrost-py3
+
+      - name: Build with enable-debug for python3, if pinned nixpkgs
+        if: matrix.nixpkgs == 'pinned'
+        run: |
+          nix build --print-build-logs .#bifrost-py3-debug
+
+      - name: Build for python38, unless nixpkgs-unstable
+        # For unstable, 3.8 packages are no longer in the build cache
+        if: matrix.nixpkgs != 'nixpkgs-unstable'
+        run: |
+          nix build --print-build-logs .#bifrost-py38
+
+      - name: Run Python test suite
+        # Skipped during nix build because it needs network data.
+        run: |
+          cd test
+          bash download_test_data.sh
+          nix run ..#python3-bifrost -- -m bifrost.telemetry --disable
+          nix run ..#python3-bifrost -- -m unittest discover
+
+      - name: Build documentation
+        run: |
+          nix build --print-build-logs --out-link result-doc .#bifrost-doc
+
+      - name: Deploy documentation to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        if: |
+          matrix.os == 'ubuntu-latest'
+          && matrix.nixpkgs == 'pinned'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/nix-flake'
+        with:
+          branch: gh-pages
+          folder: result-doc/share/doc/bifrost/html

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -71,6 +71,9 @@ jobs:
 
       - name: Deploy documentation to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4.2.5
+        # Change github.ref below to master after #162 merged.  Might
+        # only deploy if changes in doc/ folder?  (But some doc pages
+        # generated from code, so maybe should reflect code changes.)
         if: |
           matrix.os == 'ubuntu-latest'
           && matrix.nixpkgs == 'pinned'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.10.1
  * Cleaned up the Makefile outputs
+ * Added support for configurable, reproducible building with nix
 
 0.10.0
  * Switched over to an autotools-based build system

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,16 @@
     "ctypesgen": {
       "flake": false,
       "locked": {
-        "lastModified": 1645104802,
-        "narHash": "sha256-iZUJqyt2b1FAQIw5pAu9FUmyhp2Qtsu0aiQ/9QkUW/s=",
+        "lastModified": 1575761084,
+        "narHash": "sha256-0VuIufvB1TYK8EXSFr8EegNxxRxnoHsxEKQX9y7LOdY=",
         "owner": "ctypesgen",
         "repo": "ctypesgen",
-        "rev": "fd495e5edb2f69e5407774f8937a1d62cd33fe55",
+        "rev": "b7ccd0764ef7d74e9ad5816924950d05b47ecc8c",
         "type": "github"
       },
       "original": {
         "owner": "ctypesgen",
+        "ref": "ctypesgen-1.0.2",
         "repo": "ctypesgen",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "ctypesgen": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645104802,
+        "narHash": "sha256-iZUJqyt2b1FAQIw5pAu9FUmyhp2Qtsu0aiQ/9QkUW/s=",
+        "owner": "ctypesgen",
+        "repo": "ctypesgen",
+        "rev": "fd495e5edb2f69e5407774f8937a1d62cd33fe55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ctypesgen",
+        "repo": "ctypesgen",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641947035,
+        "narHash": "sha256-l4dnwWvh2Yte2I9sAwGhMG/qkvLkfV0v/ssgkZ5KNY4=",
+        "path": "/nix/store/3ck36g7rh9v9fa924h149pq7h6cx9nzx-source",
+        "rev": "9acedfd7ef32253237311dc3c78286773dbcb0d6",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1639823344,
+        "narHash": "sha256-jlsQb2y6A5dB1R0wVPLOfDGM0wLyfYqEJNzMtXuzCXw=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ff9c0b459ddc4b79c06e19d44251daa8e9cd1746",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ff9c0b459ddc4b79c06e19d44251daa8e9cd1746",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ctypesgen": "ctypesgen",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -74,11 +74,6 @@
             python3.pkgs.simplejson
           ];
           patchPhase =
-            # Remove usage of \r and tput; not conducive to build logs.
-            ''
-              sed -i -e 's:\\r::g' -e 's:echo -n:echo:' \
-                  -e 's:\(CLEAR_LINE = \).*:\1:' src/autodep.mk src/Makefile.in
-            '' +
             # libtool wants file command, and refers to it in /usr/bin
             ''
               sed -i 's:/usr/bin/file:${file}/bin/file:' configure

--- a/flake.nix
+++ b/flake.nix
@@ -114,9 +114,13 @@
               ]);
           preBuild = lib.optionalString enablePython ''
             make -C python bifrost/libbifrost_generated.py
-            sed "s:\(load_library\)(\"bifrost\"):\1('$out/lib/libbifrost.so'):"\
+            sed -e "s:^add_library_search_dirs(\[:&'$out/lib':" \
+                -e 's:name_formats = \["%s":&,"lib%s","lib%s.so":' \
                 -i python/bifrost/libbifrost_generated.py
           '';
+          # This can be a helpful addition to above sed; prints each path
+          # tried when loading library:
+          # -e "s:return self\.Lookup(path):print(path); &:" \
           makeFlags =
             lib.optionals enableCuda [ "CUDA_LIBDIR64=$(CUDA_HOME)/lib" ];
           preInstall = ''

--- a/flake.nix
+++ b/flake.nix
@@ -48,15 +48,13 @@
       bifrost = { stdenv, ctags, ncurses, file, enableDebug ? false
         , enablePython ? true, python3, enableCuda ? false, cudatoolkit
         , util-linuxMinimal, gpuArchs ? defaultGpuArchs cudatoolkit }:
-        let
-          pname = lib.optionalString (!enablePython) "lib" + "bifrost"
+        stdenv.mkDerivation {
+          name = lib.optionalString (!enablePython) "lib" + "bifrost"
             + lib.optionalString enablePython
             "-py${lib.versions.majorMinor python3.version}"
             + lib.optionalString enableCuda
             "-cuda${lib.versions.majorMinor cudatoolkit.version}"
-            + lib.optionalString enableDebug "-debug";
-        in stdenv.mkDerivation {
-          name = "${pname}-${version}";
+            + lib.optionalString enableDebug "-debug" + "-${version}";
           inherit version;
           src = ./.;
           buildInputs = [ ctags ncurses ] ++ lib.optionals enablePython [
@@ -173,9 +171,8 @@
 
       bifrost-doc =
         { stdenv, python3, ctags, doxygen, docDir ? "/share/doc/bifrost" }:
-        let pname = "bifrost-doc";
-        in stdenv.mkDerivation {
-          name = "${pname}-${version}";
+        stdenv.mkDerivation {
+          name = "bifrost-doc-${version}";
           inherit version;
           src = ./.;
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,7 @@
           do (import nixpkgs {
             inherit system;
             config.allowUnfree = true;
-            overlays = [ self.overlay ];
+            overlays = lib.attrValues self.overlays;
           }));
 
       # Which python3 packages should be modified by the overlay?
@@ -220,7 +220,7 @@
       pythonAttrs = lib.filterAttrs (name: _: isPython name);
 
     in {
-      overlay = final: prev:
+      overlays.default = final: prev:
         {
           bifrost = final.callPackage bifrost { };
           bifrost-doc = final.callPackage bifrost-doc { };
@@ -284,8 +284,8 @@
 
         in { inherit (pkgs) bifrost-doc; } // cgens // bfs // pys);
 
-      devShell = eachSystem (pkgs:
-        let
+      devShells = eachSystem (pkgs: {
+        default = let
           pre-commit = pre-commit-hooks.lib.${pkgs.system}.run {
             src = ./.;
             hooks.nixfmt.enable = true;
@@ -309,6 +309,7 @@
               pkgs.python3.pkgs.sphinx
               pkgs.yamllint
             ];
-        });
+        };
+      });
     };
 }


### PR DESCRIPTION
This is a start on specifying a “flake” for building bifrost with Nix. A flake is a format that pins all dependencies to support reproducible builds. This initial version includes github workflow for building with different releases of the nixpkgs tree (containing compilers, python dependencies, etc.) and different versions of python, then running the tests on all those configurations. (This builds on autoconf.) More background: [nixos.org](https://nixos.org/), [Flakes on Nix wiki](https://nixos.wiki/wiki/Flakes), [Flakes tutorial from tweag.io](https://www.tweag.io/blog/2020-05-25-flakes/)

It doesn't yet support GPU builds, though I've gotten it _mostly_ to work. It's a little tricky to integrate because the `libcuda.so.1` must come from the host platform, so it agrees with the kernel version and GPU hardware. If the host is itself NixOS it's manageable, but when Nix is being used on top of another platform (e.g. Ubuntu) we can only build against stubs, and then sub in the real libcuda later. For similar reasons, auto-detecting the right GPU architecture during the build seems to be problematic. As long as GPU architecture is an _input_ to the build, it gets hashed into the package signature, but we can't ask what GPU architecture is “from the inside.” Same story as for `builtins.currentSystem` for the overall architecture/OS tag. [Some hints about libcuda on Nix](https://github.com/NixOS/nixpkgs/issues/11390)

All this should be solvable (and hopefully useful). I'd like to continue to work on it and tweak it here... so marking this as a draft.