### PR TITLE
Support `python -m bifrost.version` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 doc
 version.py
+/python/bifrost/version/__init__.py
 *_generated.py
 .log*.txt
 test/data/

--- a/python/Makefile.in
+++ b/python/Makefile.in
@@ -3,7 +3,7 @@ include ../config.mk
 
 INC_DIR = ../src
 
-BIFROST_PYTHON_VERSION_FILE  = bifrost/version.py
+BIFROST_PYTHON_VERSION_FILE  = bifrost/version/__init__.py
 BIFROST_PYTHON_BINDINGS_FILE = bifrost/libbifrost_generated.py
 
 PSRHOME ?= /usr/local

--- a/python/bifrost/__init__.py
+++ b/python/bifrost/__init__.py
@@ -53,7 +53,8 @@ try:
     from bifrost.version import __version__
 except ImportError:
     print("*************************************************************************")
-    print("Please run `make` from the root of the source tree to generate version.py")
+    print("Please run `configure` and `make` from the root of the source tree to")
+    print("generate the bifrost.version module.")
     print("*************************************************************************")
     raise
 __author__     = "The Bifrost Authors"

--- a/python/bifrost/version/__main__.py
+++ b/python/bifrost/version/__main__.py
@@ -1,0 +1,7 @@
+from bifrost import __version__, __copyright__, __license__
+
+print(
+    f"""bifrost {__version__}
+{__copyright__}
+License: {__license__}"""
+)

--- a/python/bifrost/version/__main__.py
+++ b/python/bifrost/version/__main__.py
@@ -1,7 +1,3 @@
 from bifrost import __version__, __copyright__, __license__
 
-print(
-    f"""bifrost {__version__}
-{__copyright__}
-License: {__license__}"""
-)
+print("\n".join(["bifrost " + __version__, __copyright__, "License: " + __license__]))

--- a/python/bifrost/version/__main__.py
+++ b/python/bifrost/version/__main__.py
@@ -6,10 +6,7 @@ from bifrost import __version__, __copyright__, __license__
 from bifrost.libbifrost_generated import *
 
 def _yes_no(value):
-    if value:
-        return "yes"
-    else:
-        return "no"
+    return "yes" if value else "no"
 
 parser = argparse.ArgumentParser(description='Bifrost version/configuration information')
 parser.add_argument('--config', action='store_true',

--- a/python/bifrost/version/__main__.py
+++ b/python/bifrost/version/__main__.py
@@ -1,3 +1,35 @@
+from __future__ import print_function
+
+import argparse
+
 from bifrost import __version__, __copyright__, __license__
+from bifrost.libbifrost_generated import *
+
+def _yes_no(value):
+    if value:
+        return "yes"
+    else:
+        return "no"
+
+parser = argparse.ArgumentParser(description='Bifrost version/configuration information')
+parser.add_argument('--config', action='store_true',
+                    help='also display configuration information')
+args = parser.parse_args()
 
 print("\n".join(["bifrost " + __version__, __copyright__, "License: " + __license__]))
+if args.config:
+    print("\nConfiguration:")
+    print(" Memory alignment: %i B" % BF_ALIGNMENT)
+    print(" OpenMP support: %s" % _yes_no(BF_OPENMP_ENABLED))
+    print(" NUMA support %s" % _yes_no(BF_NUMA_ENABLED))
+    print(" Hardware locality support: %s" % _yes_no(BF_HWLOC_ENABLED))
+    print(" Mellanox messaging accelerator (VMA) support: %s" % _yes_no(BF_VMA_ENABLED))
+    print(" Logging directory: %s" % BF_PROCLOG_DIR)
+    print(" Debugging: %s" % _yes_no(BF_DEBUG_ENABLED))
+    print(" CUDA support: %s" % _yes_no(BF_CUDA_ENABLED))
+    if BF_CUDA_ENABLED:
+        print("  CUDA architectures: %s" % BF_GPU_ARCHS)
+        print("  CUDA shared memory: %i B" % BF_GPU_SHAREDMEM)
+        print("  CUDA managed memory support: %s" % _yes_no(BF_GPU_MANAGEDMEM))
+        print("  CUDA debugging: %s" % _yes_no(BF_CUDA_DEBUG_ENABLED))
+        print("  CUDA tracing enabled: %s" % _yes_no(BF_TRACE_ENABLED))

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ import sys
 import glob
 
 # Parse version file to extract __version__ value
-bifrost_version_file = 'bifrost/version.py'
+bifrost_version_file = 'bifrost/version/__init__.py'
 try:
     with open(bifrost_version_file, 'r') as version_file:
         for line in version_file:
@@ -50,8 +50,8 @@ except IOError:
     if 'clean' in sys.argv[1:]:
         sys.exit(0)
     print("*************************************************************************")
-    print("Please run `configure` and `make` from the root of the source tree to    ")
-    print("generate version.py                                                      ")
+    print("Please run `configure` and `make` from the root of the source tree to")
+    print(f"generate {bifrost_version_file}")
     print("*************************************************************************")
     raise
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -51,7 +51,7 @@ except IOError:
         sys.exit(0)
     print("*************************************************************************")
     print("Please run `configure` and `make` from the root of the source tree to")
-    print(f"generate {bifrost_version_file}")
+    print("generate", bifrost_version_file)
     print("*************************************************************************")
     raise
 


### PR DESCRIPTION
Just enables a simple command to print out version and copyright info:

```
% python -m bifrost.version
bifrost 0.9.0.dev+g2bc27cc
Copyright (c) 2016-2020, The Bifrost Authors. All rights reserved.
Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
License: BSD 3-Clause
```

I think it would be nice to offer many of the 'tool' scripts with this interface, e.g. `python -m bifrost.telemetry --enable` rather than (or I guess in addition to) a script file in `bin/`.