### PR TITLE
Simplify makefiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.10.1
+ * Cleaned up the Makefile outputs
+
 0.10.0
  * Switched over to an autotools-based build system
  * Added a .m4 file to help other autotools-based software find Bifrost

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,42 +101,20 @@ endif
 # TODO: Consider adding a mode 'develop=1' that makes symlinks instead of copying
 #         the library and headers.
 
-DRY_RUN ?= 0
-
 $(INSTALL_LIB_DIR)/$(LIBBIFROST_SO_MAJ_MIN): $(LIB_DIR)/$(LIBBIFROST_SO_MAJ_MIN)
-ifeq ($(DRY_RUN),0)
+	mkdir -p $(INSTALL_LIB_DIR)
 	cp $< $@
 	ln -f -s $(LIBBIFROST_SO_MAJ_MIN) $(INSTALL_LIB_DIR)/$(LIBBIFROST_SO).$(LIBBIFROST_MAJOR)
 	ln -f -s $(LIBBIFROST_SO_MAJ_MIN) $(INSTALL_LIB_DIR)/$(LIBBIFROST_SO)
-else
-	@echo "cp $< $@"
-	@echo "ln -f -s $(LIBBIFROST_SO_MAJ_MIN) $(INSTALL_LIB_DIR)/$(LIBBIFROST_SO).$(LIBBIFROST_MAJOR)"
-	@echo "ln -f -s $(LIBBIFROST_SO_MAJ_MIN) $(INSTALL_LIB_DIR)/$(LIBBIFROST_SO)"
-endif
 
 $(INSTALL_INC_DIR)/bifrost: $(INC_DIR)/bifrost/*.h #$(INC_DIR)/bifrost/*.hpp
-ifeq ($(DRY_RUN),0)
 	mkdir -p $@
 	cp $? $@/
-else
-	@echo "mkdir -p $@"
-	@echo "cp $? $@/"
-endif
 
 $(INSTALL_DAT_DIR)/bifrost: $(DAT_DIR)/*.m4
-ifeq ($(DRY_RUN),0)
 	mkdir -p $@
 	cp $? $@/
-else
-	@echo "mkdir -p $@"
-	@echo "cp $? $@/"
-endif
 
 $(INSTALL_LIB_DIR)/pkgconfig: $(DAT_DIR)/*.pc
-ifeq ($(DRY_RUN),0)
 	mkdir -p $@
 	cp $? $@/
-else
-	@echo "mkdir -p $@"
-	@echo "cp $? $@/"
-endif

--- a/python/Makefile.in
+++ b/python/Makefile.in
@@ -21,6 +21,7 @@ $(BIFROST_PYTHON_VERSION_FILE): ../config.mk
 	@echo "__version__ = \"$(LIBBIFROST_MAJOR).$(LIBBIFROST_MINOR).$(LIBBIFROST_PATCH)\"" > $@
 
 define run_ctypesgen
+        # Build the libbifrost wrapper
 	@PYTHON@ -c 'from ctypesgen import main as ctypeswrap; ctypeswrap.main()' -l$1 -I$2 $^ -o $@
 	# WAR for 'const char**' being generated as POINTER(POINTER(c_char)) instead of POINTER(c_char_p)
 	@SED@ -i.orig -e 's/POINTER(c_char)/c_char_p/g' $@

--- a/python/Makefile.in
+++ b/python/Makefile.in
@@ -50,14 +50,8 @@ build: bifrost/*.py Makefile $(BIFROST_PYTHON_VERSION_FILE) $(BIFROST_PYTHON_BIN
 	@PYTHON@ setup.py build @PYBUILDFLAGS@
 .PHONY: build
 
-DRY_RUN ?= 0
-
 install: build
-ifeq ($(DRY_RUN),0)
-	@PYTHON@ -m pip install @PYINSTALLFLAGS@ .
-else
-	@echo "@PYTHON@ -m pip install @PYINSTALLFLAGS@ ."
-endif
+	@@PYTHON@ -m pip install @PYINSTALLFLAGS@ .
 	@echo "*************************************************************************"
 	@echo "By default Bifrost installs with basic Python telemetry enabled in order"
 	@echo "to help inform how the software is used for future development.  You can"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -107,8 +107,7 @@ all: $(LIBBIFROST_SO)
 .PHONY: all
 
 $(LIBBIFROST_VERSION_FILE): $(INC_DIR)/bifrost/*.h
-	$(CLEAR_LINE)
-	@echo -n "Generating $(LIBBIFROST_VERSION_FILE)\r"
+	@echo "Generating $(LIBBIFROST_VERSION_FILE)"
 	echo "VERS_$(LIBBIFROST_MAJOR).$(LIBBIFROST_MINOR) {" > $@
 	echo "  global:" >> $@
 	@CTAGS@ -x --c-kinds=p $^ | @AWK@ '{print "    " $$1 ";"}' >> $@
@@ -135,8 +134,7 @@ fft_kernels.o: fft_kernels.cu fft_kernels.h Makefile
 	# Note: This needs to be compiled with "-dc" to make CUFFT callbacks work
 	$(NVCC) $(NVCCFLAGS) $(CPPFLAGS) -Xcompiler "$(GCCFLAGS)" -dc $(OUTPUT_OPTION) $<
 _cuda_device_link.o: Makefile fft_kernels.o libcufft_static_pruned.a
-	$(CLEAR_LINE)
-	@echo -n "Linking _cuda_device_link.o\r"
+	@echo "Linking _cuda_device_link.o"
 	# TODO: "nvcc -dlink ..." does not error or warn when a -lblah is not found
 	@ls ./libcufft_static_pruned.a > /dev/null
 	$(NVCC) -dlink -o $@ $(NVCCFLAGS) fft_kernels.o -L. -lcufft_static_pruned
@@ -152,13 +150,11 @@ endif
 
 # Note: $(LIB) must go at after OBJS
 $(LIBBIFROST_SO): $(LIBBIFROST_OBJS) $(LIBBIFROST_VERSION_FILE) $(CUDA_DEVICE_LINK_OBJ)
-	$(CLEAR_LINE)
-	@echo -n "Linking $(LIBBIFROST_SO_NAME)\r"
+	@echo "Linking $(LIBBIFROST_SO_NAME)"
 	mkdir -p $(LIB_DIR)
 	$(LINKER) $(SHARED_FLAG) -Wl,$(WLFLAGS) -o $@ $(LIBBIFROST_OBJS) $(CUDA_DEVICE_LINK_OBJ) $(LIB) $(LDFLAGS)
 	ln -s -f $(LIBBIFROST_SO_NAME) $(LIBBIFROST_SO_STEM).$(LIBBIFROST_MAJOR)
 	ln -s -f $(LIBBIFROST_SO_NAME) $(LIBBIFROST_SO_STEM)
-	$(CLEAR_LINE)
 	@echo "Successfully built $(LIBBIFROST_SO_NAME)"
 
 *.o: $(MAKEFILES)
@@ -168,8 +164,7 @@ map.o: $(JIT_SOURCES)
 stringify: stringify.cpp
 	$(CXX) -o stringify -Wall -O3 stringify.cpp
 %.jit: % stringify
-	@$(CLEAR_LINE)
-	@echo -n "Building JIT version of $<\r"
+	@echo "Building JIT version of $<"
 	./stringify $< > $@
 
 clean:

--- a/src/autodep.mk
+++ b/src/autodep.mk
@@ -17,44 +17,37 @@ COMPILE.cc   = $(CXX)  $(CXXFLAGS)  $(CPPFLAGS) $(GCCFLAGS) $(TARGET_ARCH) -c
 COMPILE.nvcc = $(NVCC) $(NVCCFLAGS) $(CPPFLAGS) -Xcompiler "$(GCCFLAGS)" $(TARGET_ARCH) -c
 POSTCOMPILE = mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d
 
-CLEAR_LINE = tput el && echo -n "\033[2K" || true # Clears the current line
-
 %.o : %.c
 %.o : %.c $(DEPDIR)/%.d
-	@$(CLEAR_LINE)
-	@echo -n "Building C source file $<\r"
+	@echo "Building C source file $<"
 	@$(DEPBUILD.c) $< > /dev/null
 	$(COMPILE.c) $(OUTPUT_OPTION) $<
 	@$(POSTCOMPILE)
 
 %.o : %.cpp
 %.o : %.cpp $(DEPDIR)/%.d
-	@$(CLEAR_LINE)
-	@echo -n "Building C++ source file $<\r"
+	@echo "Building C++ source file $<"
 	$(DEPBUILD.cc) $< > /dev/null
 	$(COMPILE.cc) $(OUTPUT_OPTION) $<
 	$(POSTCOMPILE)
 
 %.o : %.cc
 %.o : %.cc $(DEPDIR)/%.d
-	@$(CLEAR_LINE)
-	@echo -n "Building C++ source file $<\r"
+	@echo "Building C++ source file $<"
 	@$(DEPBUILD.cc) $< > /dev/null
 	$(COMPILE.cc) $(OUTPUT_OPTION) $<
 	@$(POSTCOMPILE)
 
 %.o : %.cxx
 %.o : %.cxx $(DEPDIR)/%.d
-	@$(CLEAR_LINE)
-	@echo -n "Building C++ source file $<\r"
+	@echo "Building C++ source file $<"
 	@$(DEPBUILD.cc) $< > /dev/null
 	$(COMPILE.cc) $(OUTPUT_OPTION) $<
 	@$(POSTCOMPILE)
 
 %.o : %.cu
 %.o : %.cu $(DEPDIR)/%.d
-	@$(CLEAR_LINE)
-	@echo -n "Building CUDA source file $<\r"
+	@echo "Building CUDA source file $<"
 	@$(DEPBUILD.cc) $< > /dev/null
 	$(COMPILE.nvcc) $(OUTPUT_OPTION) $<
 	@$(POSTCOMPILE)


### PR DESCRIPTION
Drop the `DRY_RUN` distinction in makefiles (`make -n` works better) and quit trying to use carriage returns `\r` in makefile output. Please see commit messages for more rationale!