### PR TITLE
In Socket.hpp, prevent warnings about sock_type comparison

### DIFF
--- a/src/Socket.hpp
+++ b/src/Socket.hpp
@@ -246,9 +246,7 @@ class Socket {
 	// Not copy-assignable
 	Socket(Socket const& );
 	Socket& operator=(Socket const& );
-#if __cplusplus >= 201103L
 	inline void replace(Socket& s);
-#endif
 	// Manage an existing socket descriptor
 	// Note: Accessible only via the named constructor Socket::manage
 	struct ManageTag {};
@@ -287,11 +285,9 @@ public:
 	}
 	
 	virtual ~Socket() { this->close(); }
-#if __cplusplus >= 201103L
 	// Move semantics
 	inline Socket(Socket&& s)                           { this->replace(s); }
 	inline Socket& operator=(Socket&& s) { this->close(); this->replace(s); return *this; }
-#endif
 	inline void swap(Socket& s);
 	// Address generator
 	// Note: Supports UNIX paths, IPv4 and IPv6 addrs, interfaces and hostnames
@@ -925,7 +921,6 @@ int Socket::addr_from_interface(const char* ifname,
 	::freeifaddrs(ifaddr);
 	return found;
 }
-#if __cplusplus >= 201103L
 void Socket::replace(Socket& s) {
 	_fd          = s._fd; s._fd = -1;
 	_type        = std::move(s._type);
@@ -936,7 +931,6 @@ void Socket::replace(Socket& s) {
 	_msgs        = std::move(s._msgs);
 	_iovecs      = std::move(s._iovecs);
 }
-#endif
 void Socket::swap(Socket& s) {
 	std::swap(_fd,          s._fd);
 	std::swap(_type,        s._type);

--- a/src/Socket.hpp
+++ b/src/Socket.hpp
@@ -282,7 +282,7 @@ public:
 		: _fd(-1), _type(type), _family(AF_UNSPEC),
 		  _mode(Socket::MODE_CLOSED) {
 		BF_ASSERT_EXCEPTION(type == SOCK_DGRAM || type == SOCK_STREAM,
-												BF_STATUS_INVALID_ARGUMENT);
+		                    BF_STATUS_INVALID_ARGUMENT);
 	}
 	
 	virtual ~Socket() { this->close(); }

--- a/src/Socket.hpp
+++ b/src/Socket.hpp
@@ -281,8 +281,9 @@ public:
 	inline explicit       Socket(int type=SOCK_DGRAM)
 		: _fd(-1), _type(type), _family(AF_UNSPEC),
 		  _mode(Socket::MODE_CLOSED) {
-		BF_ASSERT_EXCEPTION(type == SOCK_DGRAM || type == SOCK_STREAM,
-		                    BF_STATUS_INVALID_ARGUMENT);
+		if( !(type == SOCK_DGRAM || type == SOCK_STREAM) ) {
+      throw Socket::Error("Invalid socket type");
+    }
 	}
 	
 	virtual ~Socket() { this->close(); }

--- a/src/Socket.hpp
+++ b/src/Socket.hpp
@@ -280,8 +280,8 @@ public:
 		: _fd(-1), _type(type), _family(AF_UNSPEC),
 		  _mode(Socket::MODE_CLOSED) {
 		if( !(type == SOCK_DGRAM || type == SOCK_STREAM) ) {
-      throw Socket::Error("Invalid socket type");
-    }
+		  throw Socket::Error("Invalid socket type");
+		}
 	}
 	
 	virtual ~Socket() { this->close(); }

--- a/src/Socket.hpp
+++ b/src/Socket.hpp
@@ -282,8 +282,8 @@ public:
 	// Manage an existing socket (usually one returned by Socket::accept())
 	// TODO: With C++11 this could return by value (moved), which would be nicer
 	inline static Socket* manage(int fd) { return new Socket(fd, ManageTag()); }
-	inline explicit       Socket(/*sock_type*/int type=SOCK_DGRAM)
-		: _fd(-1), _type((sock_type)type), _family(AF_UNSPEC),
+	inline explicit       Socket(sock_type type=BF_SOCK_DGRAM)
+		: _fd(-1), _type(type), _family(AF_UNSPEC),
 		  _mode(Socket::MODE_CLOSED) {}
 	
 	virtual ~Socket() { this->close(); }
@@ -552,7 +552,7 @@ std::string Socket::address_string(sockaddr_storage addr) {
 	}
 }
 int Socket::discover_mtu(sockaddr_storage remote_address) {
-  Socket s(SOCK_DGRAM);
+  Socket s(BF_SOCK_DGRAM);
 	s.connect(remote_address);
 #if defined __APPLE__ && __APPLE__
   return ::get_mtu(s.get_fd());
@@ -581,7 +581,7 @@ void Socket::bind(sockaddr_storage local_address,
 	
 	check_error(::bind(_fd, (struct sockaddr*)&local_address, sizeof(local_address)),
 	            "bind socket");
-	if( _type == SOCK_STREAM ) {
+	if( _type == BF_SOCK_STREAM ) {
 		check_error(::listen(_fd, max_conn_queue),
 		            "set socket to listen");
 		_mode = Socket::MODE_LISTENING;
@@ -593,7 +593,7 @@ void Socket::bind(sockaddr_storage local_address,
 // TODO: Add timeout support? Bit of a pain to implement.
 void Socket::connect(sockaddr_storage remote_address) {
 	bool can_reuse = (_fd != -1 &&
-	                  _type == SOCK_DGRAM &&
+	                  _type == BF_SOCK_DGRAM &&
 	                  (remote_address.ss_family == AF_UNSPEC ||
 	                   remote_address.ss_family == _family));
 	if( !can_reuse ) {

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -37,7 +37,7 @@ struct BFudpsocket_impl : public Socket {
 
 BFstatus bfUdpSocketCreate(BFudpsocket* obj) {
 	BF_ASSERT(obj, BF_STATUS_INVALID_POINTER);
-	BF_TRY_RETURN_ELSE(*obj = (BFudpsocket)new BFudpsocket_impl(),//BFudpsocket_impl::BF_SOCK_DGRAM),
+	BF_TRY_RETURN_ELSE(*obj = (BFudpsocket)new BFudpsocket_impl(),//SOCK_DGRAM),
 	                   *obj = 0);
 }
 BFstatus bfUdpSocketDestroy(BFudpsocket obj) {

--- a/src/udp_socket.cpp
+++ b/src/udp_socket.cpp
@@ -32,7 +32,7 @@
 #include <bifrost/address.h>
 
 struct BFudpsocket_impl : public Socket {
-	BFudpsocket_impl() : Socket(BF_SOCK_DGRAM) {}
+	BFudpsocket_impl() : Socket(SOCK_DGRAM) {}
 };
 
 BFstatus bfUdpSocketCreate(BFudpsocket* obj) {


### PR DESCRIPTION
It looks like we're trying to use `enum sock_type` to impose a more
limited type on the `int` specified by `::socket`. But it wasn't all
the way supported, because the constructor took a general
`int` (doesn't seem to be used that way within bifrost) and there were
several comparisons between `SOCK_STREAM` (respectively `SOCK_DGRAM`)
integer constants and enum-enabled `BF_SOCK_STREAM` (`BF_SOCK_DGRAM`).

So this takes that goal further, using the enum version only. An
alternative though (in case some other client code is using a general
integer for other socket types) is just to eliminate `enum sock_type`
and (if necessary) throw an exception if passed a `SOCK_*` constant
other than those we support.

The warnings were...

```
In file included from address.cpp:30:
Socket.hpp: In member function 'void
   Socket::bind(sockaddr_storage, int)':
Socket.hpp:584:12: warning: comparison between
   'enum Socket::sock_type' and 'enum
   __socket_type' [8;;
   https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wenum-compare
   -Wenum-compare8;;]
  584 |  if( _type == SOCK_STREAM ) {
      |            ^
Socket.hpp:584:12: warning: comparison between
   types 'Socket::sock_type' and '__socket_type' [
   8;;
   https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wsign-compare
   -Wsign-compare8;;]
Socket.hpp: In member function 'void
   Socket::connect(sockaddr_storage)':
Socket.hpp:596:26: warning: comparison between
   'enum Socket::sock_type' and 'enum
   __socket_type' [8;;
   https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wenum-compare
   -Wenum-compare8;;]
  596 |                    _type == SOCK_DGRAM &&
      |                          ^
Socket.hpp:596:26: warning: comparison between
   types 'Socket::sock_type' and '__socket_type' [
   8;;
   https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wsign-compare
   -Wsign-compare8;;]
```