### PR TITLE
Resolve class/struct distinction warning from clang

### DIFF
--- a/src/proclog.hpp
+++ b/src/proclog.hpp
@@ -48,7 +48,8 @@ public:
 	}
 };
 
-class BFproclog_impl {
+struct BFproclog_impl {
+private:
 	friend class ProcLogStream;
 	std::string _filename;
 public:

--- a/src/ring_impl.hpp
+++ b/src/ring_impl.hpp
@@ -44,16 +44,17 @@
 #include <memory>
 
 class BFsequence_impl;
-class BFspan_impl;
-class BFrspan_impl;
-class BFwspan_impl;
+struct BFspan_impl;
+struct BFrspan_impl;
+struct BFwspan_impl;
 class RingReallocLock;
 class Guarantee;
 typedef std::shared_ptr<BFsequence_impl> BFsequence_sptr;
 
-class BFring_impl {
-	friend class BFrsequence_impl;
-	friend class BFwsequence_impl;
+struct BFring_impl {
+private:
+	friend struct BFrsequence_impl;
+	friend struct BFwsequence_impl;
 	friend class RingReallocLock;
 	friend class Guarantee;
 	
@@ -256,7 +257,7 @@ inline std::unique_ptr<Guarantee> new_guarantee(BFring ring) {
 }
 
 class BFsequence_impl {
-	friend class BFring_impl;
+	friend struct BFring_impl;
 	enum { BF_SEQUENCE_OPEN = (BFoffset)-1 };
 	BFring            _ring;
 	std::string       _name;
@@ -290,7 +291,7 @@ public:
 	inline BFoffset    end()         const { return _end; }
 };
 
-class BFsequence_wrapper {
+struct BFsequence_wrapper {
 protected:
 	BFsequence_sptr _sequence;
 public:
@@ -306,7 +307,8 @@ public:
 	inline BFoffset    begin()       const { return _sequence->begin(); }
 };
 
-class BFwsequence_impl : public BFsequence_wrapper {
+struct BFwsequence_impl : public BFsequence_wrapper {
+private:
 	BFoffset _end_offset_from_head;
 	BFwsequence_impl(BFwsequence_impl const& )            = delete;
 	BFwsequence_impl& operator=(BFwsequence_impl const& ) = delete;
@@ -333,7 +335,8 @@ public:
 	}
 };
 
-class BFrsequence_impl : public BFsequence_wrapper {
+struct BFrsequence_impl : public BFsequence_wrapper {
+private:
 	std::unique_ptr<Guarantee> _guarantee;
 public:
 	// TODO: See if can make these function bodies a bit more concise
@@ -376,7 +379,8 @@ public:
 	*/
 };
 
-class BFspan_impl {
+struct BFspan_impl {
+private:
 	BFring     _ring;
 	BFsize     _size;
 	// No copy or move
@@ -401,7 +405,8 @@ public:
 	virtual void*     data()     const = 0;
 	virtual BFoffset  offset()   const = 0;
 };
-class BFwspan_impl : public BFspan_impl {
+struct BFwspan_impl : public BFspan_impl {
+private:
 	BFoffset        _begin;
 	BFsize          _commit_size;
 	void*           _data;
@@ -423,7 +428,8 @@ public:
 	//         Can't easily change the name though because it's a shared API
 	inline virtual BFoffset        offset()   const { return _begin; }
 };
-class BFrspan_impl : public BFspan_impl {
+struct BFrspan_impl : public BFspan_impl {
+private:
 	BFrsequence     _sequence;
 	BFoffset        _begin;
 	void*           _data;

--- a/src/udp_capture.cpp
+++ b/src/udp_capture.cpp
@@ -530,7 +530,8 @@ inline uint64_t round_nearest(uint64_t val, uint64_t mult) {
 	return (2*val/mult+1)/2*mult;
 }
 
-class BFudpcapture_impl {
+struct BFudpcapture_impl {
+private:
 	UDPCaptureThread   _capture;
 	CHIPSDecoder       _decoder;
 	CHIPSProcessor8bit _processor;

--- a/src/udp_transmit.cpp
+++ b/src/udp_transmit.cpp
@@ -140,7 +140,8 @@ public:
 	}
 };
 
-class BFudptransmit_impl {
+struct BFudptransmit_impl {
+private:
 	UDPTransmitThread  _transmit;
 	ProcLog            _type_log;
 	ProcLog            _bind_log;


### PR DESCRIPTION
For these classes, we're declaring them a typedef with `struct NAME *`
in a `.h` file so that it can be used from C. But then the body is
defined in C++ with `class`. The clang compiler on Mac complains (but
says "I'm okay with this, but Microsoft might not be"). So it doesn't
really matter, but I'd rather get rid of the warnings if it doesn't
cost anything.

It's okay to use `struct` in C++ with inheritance and all the other
features of classes... the main difference is that `struct` members
are public by default vs `class` being private by default.

So here we turn all of these that use the typedef struct pointer C
into structs rather than classes, which silences the warnings.

```
In file included from ring.cpp:34:
./ring_impl.hpp:47:1: warning: class 'BFspan_impl' was previously declared as a
      struct; this is valid, but may result in linker errors under the Microsoft
      C++ ABI [-Wmismatched-tags]
class BFspan_impl;
^
./bifrost/ring.h:67:16: note: previous use is here
typedef struct BFspan_impl*        BFspan;
               ^
```