### PR TITLE
cufft c2r issue still persists with CUDA 11.7

### DIFF
--- a/configure
+++ b/configure
@@ -26801,7 +26801,7 @@ fi
 
 if test x$HAVE_CUDA = x1
 then :
-  cufft_c2r_modifies=$( echo $CUDA_VERSION | ${GREP} -e "10\.[1-2]" -e "11\.[0-6]" )
+  cufft_c2r_modifies=$( echo $CUDA_VERSION | ${GREP} -e "10\.[1-2]" -e "11\.[0-7]" )
        if test "$cufft_c2r_modifies" != ""; then
          echo ""
          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: This version of cuFFT may have unexpected behavior for complex-to-real transforms" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -346,7 +346,7 @@ AC_OUTPUT
 #
 
 AS_IF([test x$HAVE_CUDA = x1],
-      [cufft_c2r_modifies=$( echo $CUDA_VERSION | ${GREP} -e "10\.[[1-2]]" -e "11\.[[0-6]]" )
+      [cufft_c2r_modifies=$( echo $CUDA_VERSION | ${GREP} -e "10\.[[1-2]]" -e "11\.[[0-7]]" )
        if test "$cufft_c2r_modifies" != ""; then
          echo ""
          AC_MSG_WARN(This version of cuFFT may have unexpected behavior for complex-to-real transforms)

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -51,7 +51,7 @@ def compare(result, gold):
     np.testing.assert_allclose(result, gold, rtol=RTOL, atol=MTOL * absmean)
 
 def cudaExpectedFailure(testcase):
-    if BF_CUDA_VERSION < 10.1 or BF_CUDA_VERSION > 11.6:
+    if BF_CUDA_VERSION < 10.1 or BF_CUDA_VERSION > 11.7:
         return testcase
     return unittest.expectedFailure(testcase)
 


### PR DESCRIPTION
“Fixes” is a strong word, but I suppose this can close #180. I'm just updating the warnings and exclusion of the c2r tests for CUDA 11.7, which were reported therein. @jaycedowell, I guess it would need an autoconf rerun before merge.