### PR TITLE
Single polarization transpose works in tests and tutorial

### DIFF
--- a/test/test_transpose.py
+++ b/test/test_transpose.py
@@ -57,7 +57,9 @@ class TransposeTest(unittest.TestCase):
         for perm in permutations(range(3)):
             for shape in [(23,37,51),
                           (100, 200, 2),
-                          (2, 200, 100)]:
+                          (2, 200, 100),
+                          (100, 200, 1),
+                          (1, 200, 100)]:
                 self.run_simple_test(perm, dtype, shape)
     def test_1byte(self):
         self.run_simple_test_shmoo(np.uint8)


### PR DESCRIPTION
This is intended to make transpose work with single polarization data. This includes mono wav files used in the tutorial. Note: I initially accidentally pushed this to master and then reverted. Now it shows up as zero changed file. 