### PR TITLE
Re-enable testing the scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
                pint \
                graphviz \
                ctypesgen==1.0.2 \
+               pylint \
                coverage
       - name: "Software Install - Python, part 2"
         if: ${{ matrix.os == 'self-hosted' && matrix.python-version != '2.7' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           LD_LIBRARY_PATH: /usr/local/lib:${{ env.LD_LIBRARY_PATH }}
         run: |
+          cd testbench
           python generate_test_data.py
           coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_file_read_write.py
           coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_fft.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,7 @@ jobs:
             -m unittest discover
           coverage xml
       - name: "Test, part 2"
+        if: ${{ matrix.os == 'self-hosted' }}
         env:
           LD_LIBRARY_PATH: /usr/local/lib:${{ env.LD_LIBRARY_PATH }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,19 @@ jobs:
           coverage run --source=bifrost.ring,bifrost,bifrost.pipeline \
             -m unittest discover
           coverage xml
+      - name: "Test, part 2"
+        env:
+          LD_LIBRARY_PATH: /usr/local/lib:${{ env.LD_LIBRARY_PATH }}
+        run: |
+          python generate_test_data.py
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_file_read_write.py
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_fft.py
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline your_first_block.py
+          python download_breakthrough_listen_data.py -y
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_guppi.py
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_guppi_reader.py
+          coverage run --source=bifrost.ring,bifrost,bifrost.pipeline test_fdmt.py ./testdata/pulsars/blc0_guppi_57407_61054_PSR_J1840%2B5640_0004.fil
+          coverage xml
       - name: "Upload Coverage"
         env:
           UNITTEST_OS: ${{ matrix.os }}
@@ -108,7 +121,7 @@ jobs:
         if: ${{ matrix.os == 'self-hosted' && matrix.python-version == '3.8' }}
         uses: codecov/codecov-action@v2
         with:
-          directory: ./test/
+          files: ./test/coverage.xml, ./testbench/coverage.xml
           env_vars: UNITTEST_OS,UNITTEST_PY
           fail_ci_if_error: false
           verbose: true

--- a/python/bifrost/guppi_raw.py
+++ b/python/bifrost/guppi_raw.py
@@ -75,7 +75,7 @@ def read_header(f):
         except AttributeError:
             # Python2 catch
             pass
-        if record.startswith(b'END'):
+        if record.startswith('END'):
             break
         key, val = record.split('=', 1)
         key, val = key.strip(), val.strip()

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -52,6 +52,7 @@ try:
     run_scripts_tests = True
 except ImportError:
     pass
+run_scipts_tests &= (sys.version_info[0] >= 3)
 
 _LINT_RE = re.compile('(?P<module>.*?)\:(?P<line>\d+)\: \[(?P<type>.*?)\] (?P<info>.*)')
 

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -52,7 +52,7 @@ try:
     run_scripts_tests = True
 except ImportError:
     pass
-run_scipts_tests &= (sys.version_info[0] >= 3)
+run_scripts_tests &= (sys.version_info[0] >= 3)
 
 _LINT_RE = re.compile('(?P<module>.*?)\:(?P<line>\d+)\: \[(?P<type>.*?)\] (?P<info>.*)')
 

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -34,6 +34,11 @@ import imp
 import sys
 import glob
 
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
 TEST_DIR = os.path.dirname(__file__)
 TOOLS_DIR = os.path.join(TEST_DIR, '..', 'tools')
 TESTBENCH_DIR = os.path.join(TEST_DIR, '..', 'testbench')
@@ -42,7 +47,8 @@ BIFROST_DIR =  os.path.abspath(modInfoBuild[1])
 
 run_scripts_tests = False
 try:
-    from pylint import epylint as lint
+    from pylint.lint import Run
+    from pylint.reporters.text import TextReporter
     run_scripts_tests = True
 except ImportError:
     pass
@@ -53,11 +59,12 @@ _LINT_RE = re.compile('(?P<module>.*?)\:(?P<line>\d+)\: \[(?P<type>.*?)\] (?P<in
 class ScriptTest(unittest.TestCase):
     def _test_script(self, script):
         self.assertTrue(os.path.exists(script))
-        out, err = lint.py_run("%s -E --extension-pkg-whitelist=numpy,scipy.fftpack --init-hook='import sys; sys.path=[%s]; sys.path.insert(0, \"%s\")'" % (script, ",".join(['"%s"' % p for p in sys.path]), os.path.dirname(BIFROST_DIR)), return_std=True)
-        out_lines = out.read().split('\n')
-        err_lines = err.read().split('\n')
-        out.close()
-        err.close()
+        
+        pylint_output = StringIO()
+        reporter = TextReporter(pylint_output)
+        Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter, do_exit=False)
+        out = pylint_output.getvalue()
+        out_lines = out.split('\n')
         
         for line in out_lines:
             #if line.find("Module 'numpy") != -1:

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -62,7 +62,11 @@ class ScriptTest(unittest.TestCase):
         
         pylint_output = StringIO()
         reporter = TextReporter(pylint_output)
-        Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter, do_exit=False)
+        try:
+            Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter, do_exit=False)
+        except TypeError:
+            # Python2 catch
+            Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter)
         out = pylint_output.getvalue()
         out_lines = out.split('\n')
         


### PR DESCRIPTION
This PR addresses #208 where linting of the scripts in `tools` and testing of the scripts in `testbench` stopped when we moved away from Jenkins.

.. note:: The linting is only down by Py3 now.