### PR TITLE
Auto-detect GPU shared memory

### DIFF
--- a/config/cuda.m4
+++ b/config/cuda.m4
@@ -234,7 +234,7 @@ AC_DEFUN([AX_CHECK_CUDA],
 
     AC_ARG_WITH([shared_mem],
            [AS_HELP_STRING([--with-shared-mem=N],
-                           [default GPU shared memory in bytes (default=detect)])],
+                           [default GPU shared memory per block in bytes (default=detect)])],
            [],
            [with_shared_mem='auto'])
     if test "$with_gpu_archs" = "auto"; then

--- a/config/cuda.m4
+++ b/config/cuda.m4
@@ -22,6 +22,9 @@ AC_DEFUN([AX_CHECK_CUDA],
   AC_SUBST([CUDA_HAVE_CXX11], [0])
   AC_SUBST([GPU_MIN_ARCH], [0])
   AC_SUBST([GPU_MAX_ARCH], [0])
+  AC_SUBST([GPU_SHAREDMEM], [0])
+  AC_SUBST([GPU_PASCAL_MANAGEDMEM], [0])
+  AC_SUBST([GPU_EXP_PINNED_ALLOC], [1])
   if test "$enable_cuda" != "no"; then
     AC_SUBST([HAVE_CUDA], [1])
     
@@ -229,6 +232,62 @@ AC_DEFUN([AX_CHECK_CUDA],
     ar_max_valid=$(echo $ar_valid | ${SED} -e 's/.* //g;' )
     AC_SUBST([GPU_MAX_ARCH], [$ar_max_valid])
 
+    AC_ARG_WITH([shared_mem],
+           [AS_HELP_STRING([--with-shared-mem=N],
+                           [default GPU shared memory in bytes (default=detect)])],
+           [],
+           [with_shared_mem='auto'])
+    if test "$with_gpu_archs" = "auto"; then
+      AC_MSG_CHECKING([for minimum shared memory per block])
+
+      CXXFLAGS_save="$CXXFLAGS"
+      LDFLAGS_save="$LDFLAGS"
+      LIBS_save="$LIBS"
+      
+      LDFLAGS="-L$CUDA_HOME/lib64 -L$CUDA_HOME/lib"
+      LIBS="-lcuda -lcudart"
+      ac_run='$NVCC -o conftest$ac_ext $LDFLAGS $LIBS conftest.$ac_ext>&5'
+      AC_RUN_IFELSE([
+        AC_LANG_PROGRAM([[
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <iostream>
+            #include <fstream>
+            #include <set>]],
+            [[
+            std::set<int> smem;
+            int smemSize;
+            int deviceCount = 0;
+            cudaGetDeviceCount(&deviceCount);
+            if( deviceCount == 0 ) {
+              return 1;
+            }
+            for(int dev=0; dev<deviceCount; dev++) {
+              cudaSetDevice(dev);
+              cudaDeviceGetAttribute(&smemSize, cudaDevAttrMaxSharedMemoryPerBlock, dev);
+              if( smem.count(smemSize) == 0 ) {
+                smem.insert(smemSize);
+              }
+            }
+            std::ofstream fh;
+            fh.open("confsmem.out");
+            if( smem.empty() ) {
+              fh << 0;
+            } else {
+              fh << *smem.begin();
+            }
+            fh.close();]])],
+            [AC_SUBST([GPU_SHAREDMEM], [`cat confsmem.out`])
+             AC_MSG_RESULT([$GPU_SHAREDMEM B])],
+            [AC_MSG_ERROR(failed to determine a value)])
+
+      CXXFLAGS="$CXXFLAGS_save"
+      LDFLAGS="$LDFLAGS_save"
+      LIBS="$LIBS_save"
+    else
+      AC_SUBST([GPU_SHAREDMEM], [$with_shared_mem])
+    fi
+    
     AC_MSG_CHECKING([for Pascal-style CUDA managed memory])
     cm_invalid=$( echo $GPU_ARCHS | ${SED} -e 's/\b[[1-5]][[0-9]]\b/PRE/g;' )
     if ! echo $cm_invalid | ${GREP} -q PRE; then
@@ -261,9 +320,5 @@ AC_DEFUN([AX_CHECK_CUDA],
     CXXFLAGS="$CXXFLAGS_save"
     LDFLAGS="$LDFLAGS_save"
     LIBS="$LIBS_save"
-    
-  else
-     AC_SUBST([GPU_PASCAL_MANAGEDMEM], [0])
-     AC_SUBST([GPU_EXP_PINNED_ALLOC], [1])
   fi
 ])

--- a/configure
+++ b/configure
@@ -1563,7 +1563,8 @@ Optional Packages:
   --with-stream-model     CUDA default stream model to use: 'legacy' or
                           'per-thread' (default='per-thread')
   --with-gpu-archs=...    default GPU architectures (default=detect)
-  --with-shared-mem=N     default GPU shared memory in bytes (default=detect)
+  --with-shared-mem=N     default GPU shared memory per block in bytes
+                          (default=detect)
   --with-alignment=N      default memory alignment in bytes (default=4096)
   --with-logging-dir=DIR  directory for Bifrost proclog logging
                           (default=autodetect)

--- a/configure
+++ b/configure
@@ -716,14 +716,14 @@ HAVE_TRACE
 HAVE_DEBUG
 HAVE_TMPFS
 ALIGNMENT
-GPU_SHAREDMEM
-GPU_EXP_PINNED_ALLOC
-GPU_PASCAL_MANAGEDMEM
 GPU_ARCHS
 NVCCFLAGS
 CUOBJDUMP
 NVPRUNE
 NVCC
+GPU_EXP_PINNED_ALLOC
+GPU_PASCAL_MANAGEDMEM
+GPU_SHAREDMEM
 GPU_MAX_ARCH
 GPU_MIN_ARCH
 CUDA_HAVE_CXX11
@@ -1563,7 +1563,7 @@ Optional Packages:
   --with-stream-model     CUDA default stream model to use: 'legacy' or
                           'per-thread' (default='per-thread')
   --with-gpu-archs=...    default GPU architectures (default=detect)
-  --with-shared-mem=N     default GPU shared memory in bytes (default=16384)
+  --with-shared-mem=N     default GPU shared memory in bytes (default=detect)
   --with-alignment=N      default memory alignment in bytes (default=4096)
   --with-logging-dir=DIR  directory for Bifrost proclog logging
                           (default=autodetect)
@@ -21274,6 +21274,12 @@ fi
 
   GPU_MAX_ARCH=0
 
+  GPU_SHAREDMEM=0
+
+  GPU_PASCAL_MANAGEDMEM=0
+
+  GPU_EXP_PINNED_ALLOC=1
+
   if test "$enable_cuda" != "no"; then
     HAVE_CUDA=1
 
@@ -21717,6 +21723,94 @@ printf "%s\n" "yes" >&6; }
     GPU_MAX_ARCH=$ar_max_valid
 
 
+
+# Check whether --with-shared_mem was given.
+if test ${with_shared_mem+y}
+then :
+  withval=$with_shared_mem;
+else $as_nop
+  with_shared_mem='auto'
+fi
+
+    if test "$with_gpu_archs" = "auto"; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for minimum shared memory per block" >&5
+printf %s "checking for minimum shared memory per block... " >&6; }
+
+      CXXFLAGS_save="$CXXFLAGS"
+      LDFLAGS_save="$LDFLAGS"
+      LIBS_save="$LIBS"
+
+      LDFLAGS="-L$CUDA_HOME/lib64 -L$CUDA_HOME/lib"
+      LIBS="-lcuda -lcudart"
+      ac_run='$NVCC -o conftest$ac_ext $LDFLAGS $LIBS conftest.$ac_ext>&5'
+      if test "$cross_compiling" = yes
+then :
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <iostream>
+            #include <fstream>
+            #include <set>
+int
+main (void)
+{
+
+            std::set<int> smem;
+            int smemSize;
+            int deviceCount = 0;
+            cudaGetDeviceCount(&deviceCount);
+            if( deviceCount == 0 ) {
+              return 1;
+            }
+            for(int dev=0; dev<deviceCount; dev++) {
+              cudaSetDevice(dev);
+              cudaDeviceGetAttribute(&smemSize, cudaDevAttrMaxSharedMemoryPerBlock, dev);
+              if( smem.count(smemSize) == 0 ) {
+                smem.insert(smemSize);
+              }
+            }
+            std::ofstream fh;
+            fh.open("confsmem.out");
+            if( smem.empty() ) {
+              fh << 0;
+            } else {
+              fh << *smem.begin();
+            }
+            fh.close();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_run "$LINENO"
+then :
+  GPU_SHAREDMEM=`cat confsmem.out`
+
+             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $GPU_SHAREDMEM B" >&5
+printf "%s\n" "$GPU_SHAREDMEM B" >&6; }
+else $as_nop
+  as_fn_error $? "failed to determine a value" "$LINENO" 5
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+      CXXFLAGS="$CXXFLAGS_save"
+      LDFLAGS="$LDFLAGS_save"
+      LIBS="$LIBS_save"
+    else
+      GPU_SHAREDMEM=$with_shared_mem
+
+    fi
+
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Pascal-style CUDA managed memory" >&5
 printf %s "checking for Pascal-style CUDA managed memory... " >&6; }
     cm_invalid=$( echo $GPU_ARCHS | ${SED} -e 's/\b[1-5][0-9]\b/PRE/g;' )
@@ -21783,31 +21877,8 @@ fi
     CXXFLAGS="$CXXFLAGS_save"
     LDFLAGS="$LDFLAGS_save"
     LIBS="$LIBS_save"
-
-  else
-     GPU_PASCAL_MANAGEDMEM=0
-
-     GPU_EXP_PINNED_ALLOC=1
-
   fi
 
-
-
-# Check whether --with-shared_mem was given.
-if test ${with_shared_mem+y}
-then :
-  withval=$with_shared_mem;
-else $as_nop
-  with_shared_mem=16384
-fi
-
-GPU_SHAREDMEM=$with_shared_mem
-
-if test x$HAVE_CUDA = x0
-then :
-  GPU_SHAREDMEM=0
-
-fi
 
 #
 # Bifrost memory alignment

--- a/configure.ac
+++ b/configure.ac
@@ -153,15 +153,6 @@ AS_IF([test x$enable_vma != xno],
 
 AX_CHECK_CUDA
 
-AC_ARG_WITH([shared_mem],
-           [AS_HELP_STRING([--with-shared-mem=N],
-                           [default GPU shared memory in bytes (default=16384)])],
-           [],
-           [with_shared_mem=16384])
-AC_SUBST([GPU_SHAREDMEM], [$with_shared_mem])
-AS_IF([test x$HAVE_CUDA = x0],
-      [AC_SUBST([GPU_SHAREDMEM], [0])])
-
 #
 # Bifrost memory alignment
 #

--- a/src/linalg_kernels.cu
+++ b/src/linalg_kernels.cu
@@ -836,7 +836,7 @@ void bf_cgemm_TN_smallM_staticN_v2(int M,
 	int K_blocks = (K - 1) / BLOCK_X + 1;
 	int s_B_stride = K_blocks * BLOCK_X;
 	size_t smem = N * s_B_stride * BF_DTYPE_NBYTE(B_type)*2;
-	bool B_fits_in_shared_mem = (smem <= 48*1024);
+	bool B_fits_in_shared_mem = (smem <= BF_GPU_SHAREDMEM);
 	BF_ASSERT_EXCEPTION(B_fits_in_shared_mem, BF_STATUS_UNSUPPORTED);
 	
 	/* // TODO: Use cudaLaunchKernel instead of <<< >>>

--- a/src/linalg_kernels.h
+++ b/src/linalg_kernels.h
@@ -32,6 +32,7 @@
 
 #include <cublas_v2.h>
 
+#include <bifrost/config.h>
 #include <bifrost/array.h>
 
 inline const char* _cublasGetErrorString(cublasStatus_t status) {


### PR DESCRIPTION
This PR enables auto-detection of the GPU shared memory per block.  It also changes `linalg_kernels.cu` to use `BF_GPU_SHAREDMEM` when determining if an array can fit into shared memory.