### PR TITLE
Fix dep warning

### DIFF
--- a/python/bifrost/DataType.py
+++ b/python/bifrost/DataType.py
@@ -58,7 +58,7 @@ telemetry.track_module()
 #   E.g., np.ndarray([(0x10,), (0x32,)], dtype=ci4) # Special case
 #         np.ndarray([  (0,1),   (2,3)], dtype=ci8)
 #         np.ndarray([  (0,1),   (2,3)], dtype=ci16)
-ci4  = np.dtype([('re_im', np.int8)])
+ci4  = np.dtype([('re_im', np.uint8)])
 ci8  = np.dtype([('re', np.int8),    ('im', np.int8)])
 ci16 = np.dtype([('re', np.int16),   ('im', np.int16)])
 ci32 = np.dtype([('re', np.int32),   ('im', np.int32)])

--- a/python/bifrost/block.py
+++ b/python/bifrost/block.py
@@ -377,11 +377,11 @@ class SplitterBlock(MultiTransformBlock):
         self.header['out_2']['shape'] = sections[1]
     def load_settings(self):
         """Set the gulp sizes appropriate to the input ring"""
-        self.gulp_size['in'] = np.product(self.header['in']['shape']) * self.header['in']['nbit'] // 8
-        self.gulp_size['out_1'] = (self.gulp_size['in'] * np.product(self.header['out_1']['shape']) //
-                                   np.product(self.header['in']['shape']))
-        self.gulp_size['out_2'] = (self.gulp_size['in'] * np.product(self.header['out_2']['shape']) //
-                                   np.product(self.header['in']['shape']))
+        self.gulp_size['in'] = np.prod(self.header['in']['shape']) * self.header['in']['nbit'] // 8
+        self.gulp_size['out_1'] = (self.gulp_size['in'] * np.prod(self.header['out_1']['shape']) //
+                                   np.prod(self.header['in']['shape']))
+        self.gulp_size['out_2'] = (self.gulp_size['in'] * np.prod(self.header['out_2']['shape']) //
+                                   np.prod(self.header['in']['shape']))
     def main(self):
         """Split the incoming ring into the outputs rings"""
         for inspan, outspan1, outspan2 in self.izip(

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -476,11 +476,11 @@ class TestMultiTransformBlock(unittest.TestCase):
             if self.i > 1 and self.i < 11:
                 with self.monitor_block.rings['out_1'].open_latest_sequence(guarantee=False) as curr_seq:
                     span_gen = curr_seq.read(1)
-                    self.all_sequence_starts.append(int(next(span_gen).data[0]))
+                    self.all_sequence_starts.append(int(next(span_gen).data[0][0]))
             if self.i > 12:
                 with self.monitor_block.rings['out_1'].open_latest_sequence(guarantee=False) as curr_seq:
                     span_gen = curr_seq.read(1)
-                    self.all_sequence_starts.append(int(next(span_gen).data[0]))
+                    self.all_sequence_starts.append(int(next(span_gen).data[0][0]))
             self.i += 1
             return array
 

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -162,7 +162,7 @@ class TestMap(unittest.TestCase):
                 a_orig['im'] = np.random.randint(256, size=n)
             except ValueError:
                 # ci4 is different
-                a_orig['re_im'] = np.random.randint(256, size=n)
+                a_orig['re_im'] = np.random.randint(256, size=n, dtype=np.uint8)
             for out_dtype in (in_dtype, 'cf32'):
                 a = a_orig.copy(space='cuda')
                 b = bf.ndarray(shape=(n,), dtype=out_dtype, space='cuda')

--- a/test/test_resizing.py
+++ b/test/test_resizing.py
@@ -45,7 +45,7 @@ class ModResizeAsciiBlock(SinkBlock):
         self.shape = header_dict['shape']
         size_of_float32 = 4
         if self.gulp_size is None:
-            self.gulp_size = np.product(self.shape) * size_of_float32
+            self.gulp_size = np.prod(self.shape) * size_of_float32
     def iterate_ring_read(self, input_ring):
         """Iterate through one input ring
         @param[in] input_ring Ring to read through"""

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -64,7 +64,7 @@ class ScriptTest(unittest.TestCase):
         pylint_output = StringIO()
         reporter = TextReporter(pylint_output)
         try:
-            Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter, do_exit=False)
+            Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter, exit=False)
         except TypeError:
             # Python2 catch
             Run([script, '-E', '--extension-pkg-whitelist=numpy'], reporter=reporter)


### PR DESCRIPTION
Deprecation warnings should be gone. Notable is the change from np.int8 to np.uint8 in the ci4 datatype. One test failed because I was testing against numpy 1.25 and one of our tutorial files still requires numba, which is incompatible with numpy 1.25
