### PR TITLE
Allow `cudaMemoryTypeUnregistered`

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -63,7 +63,7 @@ BFstatus bfGetSpace(const void* ptr, BFspace* space) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 10000
 } else {
    switch( ptr_attrs.type ) {
-	   case cudaMemoryTypeUnregistered: *space = BF_SPACE_SYSTEM;       break
+	   case cudaMemoryTypeUnregistered: *space = BF_SPACE_SYSTEM;       break;
 	   case cudaMemoryTypeHost:         *space = BF_SPACE_CUDA_HOST;    break;
 	   case cudaMemoryTypeDevice:       *space = BF_SPACE_CUDA;         break;
 	   case cudaMemoryTypeManaged:      *space = BF_SPACE_CUDA_MANAGED; break;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -60,7 +60,20 @@ BFstatus bfGetSpace(const void* ptr, BFspace* space) {
 		*space = BF_SPACE_SYSTEM;
 		// WAR to avoid the ignored failure showing up later
 		cudaGetLastError();
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 10000
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+} else {
+   switch( ptr_attrs.type ) {
+	   case cudaMemoryTypeUnregistered: *space = BF_SPACE_SYSTEM;  break
+	   case cudaMemoryTypeHost:    *space = BF_SPACE_CUDA_HOST;    break;
+	   case cudaMemoryTypeDevice:  *space = BF_SPACE_CUDA;         break;
+	   case cudaMemoryTypeManaged: *space = BF_SPACE_CUDA_MANAGED; break;
+	   default: {
+		// This should never be reached
+		BF_FAIL("Valid memoryType", BF_STATUS_INTERNAL_ERROR);
+	   }
+           }
+   }
+#elif defined(CUDA_VERSION) && CUDA_VERSION >= 10000
     } else {
         switch( ptr_attrs.type ) {
 		case cudaMemoryTypeHost:    *space = BF_SPACE_SYSTEM;       break;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -60,31 +60,19 @@ BFstatus bfGetSpace(const void* ptr, BFspace* space) {
 		*space = BF_SPACE_SYSTEM;
 		// WAR to avoid the ignored failure showing up later
 		cudaGetLastError();
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 10000
 } else {
    switch( ptr_attrs.type ) {
-	   case cudaMemoryTypeUnregistered: *space = BF_SPACE_SYSTEM;  break
-	   case cudaMemoryTypeHost:    *space = BF_SPACE_CUDA_HOST;    break;
-	   case cudaMemoryTypeDevice:  *space = BF_SPACE_CUDA;         break;
-	   case cudaMemoryTypeManaged: *space = BF_SPACE_CUDA_MANAGED; break;
+	   case cudaMemoryTypeUnregistered: *space = BF_SPACE_SYSTEM;       break
+	   case cudaMemoryTypeHost:         *space = BF_SPACE_CUDA_HOST;    break;
+	   case cudaMemoryTypeDevice:       *space = BF_SPACE_CUDA;         break;
+	   case cudaMemoryTypeManaged:      *space = BF_SPACE_CUDA_MANAGED; break;
 	   default: {
 		// This should never be reached
 		BF_FAIL("Valid memoryType", BF_STATUS_INTERNAL_ERROR);
 	   }
            }
    }
-#elif defined(CUDA_VERSION) && CUDA_VERSION >= 10000
-    } else {
-        switch( ptr_attrs.type ) {
-		case cudaMemoryTypeHost:    *space = BF_SPACE_SYSTEM;       break;
-		case cudaMemoryTypeDevice:  *space = BF_SPACE_CUDA;         break;
-		case cudaMemoryTypeManaged: *space = BF_SPACE_CUDA_MANAGED; break;
-		default: {
-			// This should never be reached
-			BF_FAIL("Valid memoryType", BF_STATUS_INTERNAL_ERROR);
-		}
-		}
-	}
 #else
 	} else if( ptr_attrs.isManaged ) {
 		*space = BF_SPACE_CUDA_MANAGED;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2016-2023, The Bifrost Authors. All rights reserved.
  * Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This PR addresses a change in behavior of `cudaPointerGetAttributes` starting in CUDA 11 .  Before CUDA 11 "normal" system memory (that allocated outside of CUDA) would generate an error return code.  Starting with CUDA 11 the call returns success with a `memoryType` of `cudaMemoryTypeUnregistered`.  This updates `memory.cpp` to allow this type for CUDA 10+ and map it to `BF_SPACE_SYSTEM`.  `cudaMemoryTypeHost` is also now mapped to `BF_SPACE_CUDA_HOST`.