### PR TITLE
Explicitly include cstdint for gcc13

### DIFF
--- a/src/trace.hpp
+++ b/src/trace.hpp
@@ -39,6 +39,7 @@
 #include <queue>
 #include <string>
 #include <cstring>
+#include <cstdint>
 
 #if BF_TRACE_ENABLED
 // Note: __PRETTY_FUNCTION__ is GCC-specific

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cstring> // For ::memcpy
+#include <cstdint>
 #include <cassert>
 
 #define BF_DTYPE_IS_COMPLEX(dtype) bool((dtype) & BF_DTYPE_COMPLEX_BIT)


### PR DESCRIPTION
My newish laptop has gcc13 by default. It needs explicit `<cstdint>` to define `uint64_t` and friends.

https://gcc.gnu.org/gcc-13/porting_to.html
