### PR TITLE
Lockfile will warn periodically if waiting more than 5s

### DIFF
--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -29,6 +29,7 @@
 #include "fileutils.hpp"
 #include <sstream>
 #include <iostream>
+#include <cstring> // strerror
 
 #if defined(HAVE_CXX_FILESYSTEM) && HAVE_CXX_FILESYSTEM
 #include <filesystem>
@@ -188,52 +189,74 @@ std::string get_dirname(std::string filename) {
 #endif
 }
 
-/* NOTE: In case of abnormal exit (such as segmentation fault or other signal),
-   the lock file will not be removed, and the next attempt to lock might busy-
-   wait until the file is manually deleted. If this is a common issue, we could
-   potentially write the PID into the lock file to help with tracking whether
-   the process died. */
 LockFile::LockFile(std::string lockfile) : _lockfile(lockfile) {
-	time_t start = time(NULL), elapsed = 0;
-	int busycount = 0;
-	int busyinterval = 1 << 17;
-	while( true ) {
-		_fd = open(_lockfile.c_str(), O_CREAT, 600);
-		flock(_fd, LOCK_EX);
-		struct stat fd_stat, lockfile_stat;
-		fstat(_fd, &fd_stat);
-		stat(_lockfile.c_str(), &lockfile_stat);
-		// Compare inodes
-		if( fd_stat.st_ino == lockfile_stat.st_ino ) {
-			// Got the lock
-			if(elapsed > 0) {
-				std::cerr << "NOTE: acquired " << lockfile
-				          << std::endl;
-			}
-			break;
-		}
-		busycount++;
-		close(_fd);
-		if(busycount % busyinterval == 0) {
-			elapsed = time(NULL) - start;
-			if(elapsed >= 5) {
-				std::cerr << "NOTE: waiting " << elapsed
-				          << "s for " << lockfile << std::endl;
-				busyinterval = busycount;
-			}
-		}
-	}
+  time_t start = time(NULL), elapsed = 0;
+  long busycount = 0;
+  long busyinterval = 1 << 17;
+  pid_t pid = getpid();
+  while( true ) {
+    _fd = open(_lockfile.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR);
+    if( _fd == -1 ) {
+      if(busycount == 0) {
+        std::cerr << "ERROR: could not create " << lockfile << ": "
+                  << strerror(errno) << std::endl;
+      }
+    }
+    else {
+      if( flock(_fd, LOCK_EX | LOCK_NB) == 0 ) {
+        struct stat fd_stat, lockfile_stat;
+        fstat(_fd, &fd_stat);
+        stat(_lockfile.c_str(), &lockfile_stat);
+        if( fd_stat.st_ino == lockfile_stat.st_ino ) {
+          // We acquired the lock. Announce it only if we announced waiting.
+          if(elapsed > 0) {
+            std::cerr << "NOTE: acquired " << lockfile << std::endl;
+          }
+          // Exit the busy loop
+          break;
+        }
+        // Locking succeeded, but inodes were different so try again.
+        flock(_fd, LOCK_UN);
+      }
+      close(_fd);
+    }
+    busycount++;
+    if(busycount % busyinterval == 0) {
+      elapsed = time(NULL) - start;
+      if(elapsed >= 5) {
+        std::cerr << "NOTE: waiting " << elapsed
+                  << "s for " << lockfile << std::endl;
+        busyinterval = busycount;
+      }
+    }
+  }
+  // We have the lock, so try writing PID.
+  if(ftruncate(_fd, 0) == -1) {
+    std::cerr << "WARNING: could not truncate " << lockfile << ": "
+              << strerror(errno) << std::endl;
+  }
+  else {
+    std::ostringstream ss;
+    ss << pid << '\n';
+    std::string buf = ss.str();
+    if(write(_fd, buf.c_str(), buf.size()) != (ssize_t)buf.size()) {
+      std::cerr << "WARNING: could not write to " << lockfile << ": "
+                << strerror(errno) << std::endl;
+    }
+  }
 }
 
 LockFile::~LockFile() {
-	unlink(_lockfile.c_str());
-	flock(_fd, LOCK_UN);
+  unlink(_lockfile.c_str());
+  flock(_fd, LOCK_UN);
+  close(_fd);
 }
 
 
 #ifdef FILEUTILS_LOCKFILE_TEST
-// This is a little test program for LockFile, to simulate
-// a leftover lock file. It should look something like this:
+// This is a little test program for LockFile. Run it in two terminals
+// to simulate race conditions, or kill one to leave a a leftover lock file.
+// Output should look something like this:
 
 //    Initiating lock...
 //    NOTE: waiting 5s for ./myfile.lock
@@ -243,11 +266,13 @@ LockFile::~LockFile() {
 //    [Delete the file from another terminal]
 //    NOTE: acquired ./myfile.lock
 //    Lock acquired... exiting
+
 int main() {
-  int fd = open("./myfile.lock", O_CREAT, 600);
   std::cerr << "Initiating lock..." << std::endl;
-  LockFile("./myfile.lock");
-  std::cerr << "Lock acquired... exiting" << std::endl;
+  LockFile lock("./myfile.lock");
+  std::cerr << "Lock acquired, 'working' for 15s..." << std::endl;
+  sleep(15);
+  std::cerr << "Work finished, releasing lock..." << std::endl;
   return 0;
 }
 #endif

--- a/src/fileutils.hpp
+++ b/src/fileutils.hpp
@@ -36,6 +36,7 @@
 #include <unistd.h>    // For getpid
 #include <pwd.h>       // For getpwuid
 #include <system_error>
+#include <string>
 
 #if defined(__APPLE__) && __APPLE__
 #include <sys/sysctl.h>


### PR DESCRIPTION
Fixes #232.

I think this is ready to go. There's a self-contained test program at the bottom of the file, it's easy to compile and test in isolation.

Is a `cerr` message good enough?
