### PR TITLE
Mac builds with Python 3.6 are failing in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,6 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: '3.6'
-          - os: macos-latest
-            python-version: '3.6'
       fail-fast: false
     steps:
       - name: "Software Install - Ubuntu"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
             gawk \
             gnu-sed \
             pkg-config
-      - uses: actions/setup-python@v5.0.0
+      - uses: actions/setup-python@v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Software Install - Python"


### PR DESCRIPTION
The transcript says:

```
  Version 3.6 was not found in the local cache
  Error: The version '3.6' with architecture 'arm64' was not found for macOS 14.4.1.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

That list does contain some 3.6.x, but then I noticed the part about "architecture arm64"… so [this comment](https://github.com/actions/setup-python/issues/856#issuecomment-2083483754) seems to be relevant:

> For me this looks like it's probably that the macos-latest Github action runner appears to have switched to an M1 ARM mac, where at least last week macos-latest was an x86 mac.

So I see a couple of options:
- Pin `macos-latest` to an earlier revision so we're still ensuring x86, or
- Drop 3.6 from CI for mac. It's already excluded for self-hosted, but we're still using it on Ubuntu.
