### PR TITLE
Fix DeprecationWarning: invalid escape sequence \d

### DIFF
--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -53,7 +53,7 @@ except ImportError:
     pass
 run_scripts_tests &= (sys.version_info[0] >= 3)
 
-_LINT_RE = re.compile('(?P<module>.*?)\:(?P<line>\d+)\: \[(?P<type>.*?)\] (?P<info>.*)')
+_LINT_RE = re.compile(r'(?P<module>.*?)\:(?P<line>\d+)\: \[(?P<type>.*?)\] (?P<info>.*)')
 
 @unittest.skipUnless(run_scripts_tests, "requires the 'pylint' module")
 class ScriptTest(unittest.TestCase):

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -32,7 +32,6 @@ Unit tests for the various Bifrost tutorial notebooks.
 import unittest
 import glob
 import sys
-import re
 import os
 from tempfile import mkdtemp
 from shutil import rmtree

--- a/tools/like_pmap.py
+++ b/tools/like_pmap.py
@@ -92,7 +92,7 @@ def main(args):
         raise RuntimeError("Cannot find NUMA memory info for PID: %i" % args.pid)
         
     # Parse out the anonymous entries in this file
-    _numaRE = re.compile('(?P<addr>[0-9a-f]+).*[(anon)|(mapped)]=(?P<size>\d+).*(swapcache=(?P<swap>\d+))?.*N(?P<binding>\d+)=(?P<size2>\d+)')
+    _numaRE = re.compile(r'(?P<addr>[0-9a-f]+).*[(anon)|(mapped)]=(?P<size>\d+).*(swapcache=(?P<swap>\d+))?.*N(?P<binding>\d+)=(?P<size2>\d+)')
     areas = {}
     files = {}
     for line in numaInfo.split('\n'):


### PR DESCRIPTION
Two places where regexes used `\d` without being "raw" strings. The one in `like_pmap` was showing up in tests as:

```
like_pmap:95: DeprecationWarning: invalid escape sequence '\d'
```

~Though it's not yet clear to me how/why `like_pmap` is being imported into any tests...?~
